### PR TITLE
feat: add *rest.Config to kind.Cluster

### DIFF
--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -3,7 +3,7 @@ name: Integration Tests
 on: [pull_request]
 
 jobs:
-  test:
+  kind-cluster-test:
     runs-on: ubuntu-latest
     steps:
     - name: setup golang
@@ -19,11 +19,5 @@ jobs:
           ${{ runner.os }}-go
     - name: checkout repository
       uses: actions/checkout@v2
-    - name: Login to GitHub Packages Docker Registry
-      uses: docker/login-action@v1
-      with:
-        registry: docker.pkg.github.com
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     - name: run integration tests
       run: make test.integration

--- a/pkg/kind/cluster.go
+++ b/pkg/kind/cluster.go
@@ -2,6 +2,7 @@ package kind
 
 import (
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // -----------------------------------------------------------------------------
@@ -15,6 +16,9 @@ type Cluster interface {
 
 	// Client is the configured *kubernetes.Clientset which can be used to access the Cluster's API
 	Client() *kubernetes.Clientset
+
+	// Config provides the *rest.Config for the cluster which is convenient for initiating custom kubernetes.Clientsets.
+	Config() *rest.Config
 
 	// Cleanup obliterates the cluster and all of its resources, leaving no garbage behind, unless `KIND_KEEP_CLUSTER` is set.
 	Cleanup() error

--- a/pkg/kind/kong_proxy_cluster_configuration.go
+++ b/pkg/kind/kong_proxy_cluster_configuration.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/helm"
 	"github.com/kong/kubernetes-testing-framework/pkg/metallb"
@@ -50,7 +51,7 @@ func (c *ClusterConfigurationWithKongProxy) Deploy(ctx context.Context) (Cluster
 		return nil, nil, fmt.Errorf("CreateCluster() failed: %w", err)
 	}
 
-	kc, err := ClientForCluster(name)
+	cfg, kc, err := ClientForCluster(name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -58,6 +59,7 @@ func (c *ClusterConfigurationWithKongProxy) Deploy(ctx context.Context) (Cluster
 	cluster := &kongProxyCluster{
 		name:         name,
 		client:       kc,
+		cfg:          cfg,
 		enabledMetal: c.EnableMetalLB,
 	}
 
@@ -93,6 +95,10 @@ func (c *kongProxyCluster) Client() *kubernetes.Clientset {
 	return c.client
 }
 
+func (c *kongProxyCluster) Config() *rest.Config {
+	return c.cfg
+}
+
 // -----------------------------------------------------------------------------
 // Kong Proxy Cluster - Private Types
 // -----------------------------------------------------------------------------
@@ -100,5 +106,6 @@ func (c *kongProxyCluster) Client() *kubernetes.Clientset {
 type kongProxyCluster struct {
 	name         string
 	client       *kubernetes.Clientset
+	cfg          *rest.Config
 	enabledMetal bool
 }


### PR DESCRIPTION
Adding the *rest.Config as a returnable to the kind.Cluster
interface adds convenience for callers who want to generate
custom clientsets for their own typed clients for the cluster.
