### PR TITLE
feat: allow custom name cluster deploys

### DIFF
--- a/pkg/kind/cluster.go
+++ b/pkg/kind/cluster.go
@@ -23,3 +23,20 @@ type Cluster interface {
 	// Cleanup obliterates the cluster and all of its resources, leaving no garbage behind, unless `KIND_KEEP_CLUSTER` is set.
 	Cleanup() error
 }
+
+// -----------------------------------------------------------------------------
+// Public Types - Existing Cluster
+// -----------------------------------------------------------------------------
+
+// GetExistingCluster provides a Cluster object for a given kind cluster by name.
+func GetExistingCluster(name string) (Cluster, error) {
+	cfg, kc, err := ClientForCluster(name)
+	if err != nil {
+		return nil, err
+	}
+	return &kongProxyCluster{
+		name:   name,
+		client: kc,
+		cfg:    cfg,
+	}, nil
+}

--- a/pkg/kind/kong_cluster.go
+++ b/pkg/kind/kong_cluster.go
@@ -42,7 +42,11 @@ type ClusterConfigurationWithKongProxy struct {
 
 // Deploy is a factory method to generate kind.Cluster objects given the configuration, with new names being selected on each deploy.
 func (c *ClusterConfigurationWithKongProxy) Deploy(ctx context.Context) (Cluster, chan ProxyReadinessEvent, error) {
-	name := uuid.New().String()
+	return c.DeployWithName(ctx, uuid.New().String())
+}
+
+// DeployWithName is a factory method to generate kind.Cluster objects given the configuration with a custom name provided.
+func (c *ClusterConfigurationWithKongProxy) DeployWithName(ctx context.Context, name string) (Cluster, chan ProxyReadinessEvent, error) {
 
 	if c.DockerNetwork == "" {
 		c.DockerNetwork = DefaultKindDockerNetwork


### PR DESCRIPTION
This PR adds a shim for allowing overrides of cluster names on `Deploy()` from a proxy only configuration.