### PR TITLE
Add Github Actions Environment

### DIFF
--- a/.github/workflows/test_integration.yaml
+++ b/.github/workflows/test_integration.yaml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   kind-cluster-test:
+    environment: ci
     runs-on: ubuntu-latest
     steps:
     - name: setup golang


### PR DESCRIPTION
Codecov no longer allows us to anonymously report coverage for this repo, so we have to use Github Actions Environments going forward to include our codecov api key in the CI environment.