### PR TITLE
fix: use bash for install script

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Use bash for the install script instead of sh. The KTF install script
relies on some bash-specific shell builtins (set -o pipefail) and won't
run with plain sh.

This partially addresses the issue encountered in https://github.com/Kong/charts/runs/3060680578?check_suite_focus=true