### PR TITLE
[feat] proxy only mode

### DIFF
--- a/internal/cmd/environments.go
+++ b/internal/cmd/environments.go
@@ -39,6 +39,7 @@ func init() {
 	// addon configurations
 	environmentsCreateCmd.PersistentFlags().StringArray("addon", nil, "name of an addon to deploy to the testing environment's cluster")
 	environmentsCreateCmd.PersistentFlags().Bool("kong-disable-controller", false, "indicate whether the kong addon should have the controller disabled (proxy only)")
+	environmentsCreateCmd.PersistentFlags().String("kong-dbmode", "off", "indicate the backend dbmode to use for kong (default: \"off\" (DBLESS mode))")
 }
 
 var environmentsCreateCmd = &cobra.Command{
@@ -115,6 +116,18 @@ func configureKongAddon(cmd *cobra.Command, envBuilder *environments.Builder) *e
 
 	disableController, err := cmd.PersistentFlags().GetBool("kong-disable-controller")
 	cobra.CheckErr(err)
+
+	dbmode, err := cmd.PersistentFlags().GetString("kong-dbmode")
+	cobra.CheckErr(err)
+
+	switch dbmode {
+	case "off":
+		builder.WithDBLess()
+	case "postgres":
+		builder.WithPostgreSQL()
+	default:
+		cobra.CheckErr(fmt.Errorf("%s is not a valid dbmode for kong, supported modes are \"off\" (DBLESS) or \"postgres\"", dbmode))
+	}
 
 	if disableController {
 		builder.WithControllerDisabled()

--- a/internal/cmd/environments.go
+++ b/internal/cmd/environments.go
@@ -21,8 +21,9 @@ func init() {
 }
 
 var environmentsCmd = &cobra.Command{
-	Use:   "environments",
-	Short: "create and manage testing environments",
+	Use:     "environments",
+	Aliases: []string{"environs", "envs", "env"},
+	Short:   "create and manage testing environments",
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -10,6 +10,7 @@ type Builder struct {
 	name       string
 	deployArgs []string
 	dbmode     DBMode
+	proxyOnly  bool
 }
 
 // NewBuilder provides a new Builder object for configuring and generating
@@ -35,6 +36,12 @@ func (b *Builder) WithPostgreSQL() *Builder {
 	return b
 }
 
+// WithControllerDisabled configures the Addon in proxy only mode (bring your own control plane).
+func (b *Builder) WithControllerDisabled() *Builder {
+	b.proxyOnly = true
+	return b
+}
+
 // Build generates a new kong cluster.Addon which can be loaded and deployed
 // into a test Environment's cluster.Cluster.
 func (b *Builder) Build() *Addon {
@@ -42,5 +49,6 @@ func (b *Builder) Build() *Addon {
 		dbmode:     b.dbmode,
 		namespace:  b.namespace,
 		deployArgs: b.deployArgs,
+		proxyOnly:  b.proxyOnly,
 	}
 }

--- a/test/integration/kind_cluster_test.go
+++ b/test/integration/kind_cluster_test.go
@@ -3,15 +3,20 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
@@ -24,7 +29,7 @@ func TestEnvWithKindCluster(t *testing.T) {
 	builder := environment.NewBuilder()
 
 	t.Log("building the testing environment and Kubernetes cluster")
-	env, err := builder.Build(ctx)
+	env, err := builder.WithAddons(metallb.New(), kong.New()).Build(ctx)
 	require.NoError(t, err)
 
 	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())
@@ -33,8 +38,8 @@ func TestEnvWithKindCluster(t *testing.T) {
 		require.NoError(t, env.Cleanup(ctx))
 	}()
 
-	t.Log("verifying that no addons have been loaded into the environment")
-	require.Len(t, env.Cluster().ListAddons(), 0)
+	t.Log("verifying that both addons have been loaded into the environment")
+	require.Len(t, env.Cluster().ListAddons(), 2)
 
 	t.Log("waiting for the test environment to be ready for use")
 	require.NoError(t, <-env.WaitForReady(ctx))
@@ -44,6 +49,21 @@ func TestEnvWithKindCluster(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, waitForObjects, 0)
 	require.True(t, ready)
+
+	t.Logf("pulling the kong addon from the environment's cluster to verify proxy URL")
+	kongAddon, err := env.Cluster().GetAddon("kong")
+	require.NoError(t, err)
+	kongAddonRaw, ok := kongAddon.(*kong.Addon)
+	require.True(t, ok)
+	proxyURL, err := kongAddonRaw.ProxyURL(ctx, env.Cluster())
+	require.NoError(t, err)
+
+	t.Log("verifying that the kong addon deployed both proxy and controller")
+	kongDeployment, err := env.Cluster().Client().AppsV1().Deployments(kongAddonRaw.Namespace()).Get(ctx, "ingress-controller-kong", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, kongDeployment.Spec.Template.Spec.Containers, 2)
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[0].Name, "ingress-controller")
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[1].Name, "proxy")
 
 	t.Log("deploying a test deployment to ensure the environment's cluster is working")
 	container := generators.NewContainer("httpbin", "docker.io/kennethreitz/httpbin", 80)
@@ -60,18 +80,44 @@ func TestEnvWithKindCluster(t *testing.T) {
 		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
 	}, time.Minute*1, time.Second*1)
 
-	t.Logf("deleting the test deployment %s", deployment.Name)
-	require.NoError(t, env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Delete(ctx, deployment.Name, metav1.DeleteOptions{}))
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
 
-	t.Log("verifying deletion of the deployment")
+	t.Logf("creating an ingress for service %s with ingress.class kong", service.Name)
+	ingress := generators.NewIngressForService("/httpbin", map[string]string{
+		"kubernetes.io/ingress.class": "kong",
+		"konghq.com/strip-path":       "true",
+	}, service)
+	ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Create(ctx, ingress, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("waiting for ingress status update to validate that the kong controller is functioning")
 	require.Eventually(t, func() bool {
-		deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, deployment.Name, metav1.GetOptions{})
+		ingress, err = env.Cluster().Client().NetworkingV1().Ingresses(corev1.NamespaceDefault).Get(ctx, ingress.Name, metav1.GetOptions{})
 		if err != nil {
-			if errors.IsNotFound(err) {
-				return true
-			}
+			return false
+		}
+		return len(ingress.Status.LoadBalancer.Ingress) > 0
+	}, time.Minute*1, time.Second*1)
+
+	t.Logf("accessing the deployment via ingress %s to validate that the kong proxy is functioning", ingress.Name)
+	httpc := http.Client{Timeout: time.Second * 3}
+	require.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			b := new(bytes.Buffer)
+			n, err := b.ReadFrom(resp.Body)
+			require.NoError(t, err)
+			require.True(t, n > 0)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
 		}
 		return false
 	}, time.Minute*1, time.Second*1)
-
 }


### PR DESCRIPTION
This PR adds tooling to enable the latent capability to deploy a test environment with the Kong addon configured in a "proxy only" mode in both Go library and CLI use cases.

This is a backwards incompatible change, because the default used to be "proxy only" and now the default is to enable the controller.

- feat: enable proxy-only mode for kong addon
- feat: enable --kong-disable-controller flag for env cli
- feat: add --kong-dbmode flag for env CLI
- feat: environments cli aliases
- chore: add tests to validate default kong addon configurations
- chore: add test for proxy only deployment
