### PR TITLE
[feat] add k8s version for environment builder

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
       - 'main'
   push:
     branches:
-      - '*'
+      - 'main'
     tags:
       - '*'
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-./ktf*
+ktf*
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
Clusters already have the ability to designate a specific
Kubernetes version, this patch forwards that ability up
through the environment which creates the cluster and makes
the functionality available via CLI using the newly added
flag ktf env create --kubernetes-version <VERSION>.

In support of https://github.com/Kong/charts/issues/391