### PR TITLE
[feat] GKE Cluster Support

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,43 @@
+name: lint
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.16'
+
+    # TODO: had to temporarily disable the caching, it appears its not
+    #       concurrency safe and multiple CI runs corrupted the cache.
+    #       Github is not yet willing to add a feature to clear it:
+    #         - https://github.com/actions/cache/issues/2
+    #
+    #- name: cache go modules
+    #  uses: actions/cache@v2.1.6
+    #  with:
+    #    path: ~/go/pkg/mod
+    #    key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+    #    restore-keys: |
+    #      ${{ runner.os }}-go
+
+    - name: checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v2.5.2
+      with:
+        version: v1.40.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    environment: gcloud
     runs-on: ubuntu-latest
     steps:
 
@@ -29,6 +30,20 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    # --------------------------------------------------------------------------
+    # Tests
+    # --------------------------------------------------------------------------
+
+    - name: run unit & integration tests
+      run: make test.all
+
+    - name: run e2e tests
+      run: make test.e2e
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+        GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
 
     # --------------------------------------------------------------------------
     # Github Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./ktf.linux.amd64
+        asset_path: ./build/ktf.linux.amd64
         asset_name: ktf.linux.amd64
         asset_content_type: application/octet-stream
 
@@ -86,7 +86,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./ktf.darwin.amd64
+        asset_path: ./build/ktf.darwin.amd64
         asset_name: ktf.darwin.amd64
         asset_content_type: application/octet-stream
 
@@ -96,9 +96,11 @@ jobs:
 
     - name: generate checksums for linux amd64 artifacts
       run: sha256sum ktf.linux.amd64 >> CHECKSUMS
+      working-directory: ./build/
 
     - name: generate checksums for mac amd64 artifacts
       run: sha256sum ktf.darwin.amd64 >> CHECKSUMS
+      working-directory: ./build/
 
     - name: upload checksums
       uses: actions/upload-release-asset@v1
@@ -106,7 +108,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: CHECKSUMS
+        asset_path: ./build/CHECKSUMS
         asset_name: CHECKSUMS
         asset_content_type: text/plain
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-ktf*
+build/*
 
 # Test binary, built with `go test -c`
 *.test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,35 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+  - asciicheck
+  - bodyclose
+  - deadcode
+  - depguard
+  - dogsled
+  - durationcheck
+  - errcheck
+  - exhaustive
+  - exportloopref
+  - gochecknoinits
+  - gofmt
+  - goimports
+  - gomnd
+  - gosec
+  - gosimple
+  - govet
+  - importas
+  - ineffassign
+  - megacheck
+  - misspell
+  - nilerr
+  - nolintlint
+  - predeclared
+  - revive
+  - staticcheck
+  - structcheck
+  - typecheck
+  - unconvert
+  - unparam
+  - varcheck
+  - wastedassign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.3.0 (TBD)
+
+### Improvements
+
+* GKE Cluster implementation added.
+  ([#32](https://github.com/Kong/kubernetes-testing-framework/issues/32))
+
+### Breaking Changes
+
+* Previously when KIND was the only Cluster implementation
+  we defaulted to exposing the Kong Admin API via a LoadBalancer
+  type service as this would not be accessible outside of the
+  local docker network. Now that a GKE Cluster implementation
+  exists this default would no longer be secure, so the default
+  has been changed to ClusterIP.
+  ([#32](https://github.com/Kong/kubernetes-testing-framework/issues/32))
+
 ## v0.2.2
 
 ### Security Fixes

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ build:
 	mkdir -p build/
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o build/ktf.$(GOOS).$(GOARCH) internal/cmd/main.go
 
+.PHONY: lint
+lint:
+	@golangci-lint run ./...
+
 .PHONY: test
 test: test.unit
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ test.all: test.integration
 test.unit:
 	go test -race -v ./pkg/...
 
+.PHONY: test.e2e
+test.e2e:
+	@GOFLAGS="-tags=e2e_tests" go test -race -v -timeout 15m ./test/e2e/...
+
 .PHONY: test.integration
 test.integration:
 	@GOFLAGS="-tags=integration_tests" go test -race -v \

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,12 @@ all: build
 
 .PHONY: clean
 clean:
-	rm -f ktf*
+	rm -rf build/
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ktf.$(GOOS).$(GOARCH) cmd/ktf/main.go
+	mkdir -p build/
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o build/ktf.$(GOOS).$(GOARCH) internal/cmd/main.go
 
 .PHONY: test
 test: test.unit

--- a/cmd/ktf/main.go
+++ b/cmd/ktf/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/kong/kubernetes-testing-framework/internal/cmd"
-
-func main() {
-	cmd.Execute()
-}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kong/kubernetes-testing-framework
 go 1.16
 
 require (
+	cloud.google.com/go v0.81.0
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containerd/containerd v1.4.8 // indirect
@@ -25,7 +26,8 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	google.golang.org/genproto v0.0.0-20210726200206-e7812ac95cc0 // indirect
+	google.golang.org/api v0.44.0
+	google.golang.org/genproto v0.0.0-20210726200206-e7812ac95cc0
 	gotest.tools/v3 v3.0.3 // indirect
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKP
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
+cloud.google.com/go v0.81.0 h1:at8Tk2zUz63cLPR0JPWm5vp77pEZmzxEQBEfRKn1VV8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -128,6 +129,7 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -194,6 +196,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyycI+I=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
@@ -366,6 +369,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -632,6 +636,7 @@ google.golang.org/api v0.36.0/go.mod h1:+z5ficQTmoYpPn8LCUNVpK5I7hwkpjbcgqA7I34q
 google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjRCQ8=
 google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBzRTU=
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
+google.golang.org/api v0.44.0 h1:URs6qR1lAxDsqWITsQXI4ZkGiYJ5dHtRNiCpfs2OeKA=
 google.golang.org/api v0.44.0/go.mod h1:EBOGZqzyhtvMDoxwS97ctnh0zUmYY6CxqXsc1AvkYD8=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -1,4 +1,4 @@
-package cmd
+package ktf
 
 import (
 	"context"
@@ -18,7 +18,7 @@ import (
 // Environments - Base Command
 // -----------------------------------------------------------------------------
 
-func init() {
+func init() { //nolint:gochecknoinits
 	rootCmd.AddCommand(environmentsCmd)
 }
 
@@ -32,7 +32,7 @@ var environmentsCmd = &cobra.Command{
 // Environments - Create Subcommand
 // -----------------------------------------------------------------------------
 
-func init() {
+func init() { //nolint:gochecknoinits
 	environmentsCmd.AddCommand(environmentsCreateCmd)
 
 	// environment naming
@@ -155,7 +155,7 @@ func configureKongAddon(cmd *cobra.Command, envBuilder *environments.Builder) *e
 // Environments - Delete Subcommand
 // -----------------------------------------------------------------------------
 
-func init() {
+func init() { //nolint:gochecknoinits
 	environmentsCmd.AddCommand(environmentsDeleteCmd)
 	environmentsDeleteCmd.PersistentFlags().String("name", DefaultEnvironmentName, "name of the environment to delete")
 }

--- a/internal/cmd/ktf/init.go
+++ b/internal/cmd/ktf/init.go
@@ -1,4 +1,4 @@
-package cmd
+package ktf
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 
 var cfgFile string
 
-func init() {
+func init() { //nolint:gochecknoinits
 	// config init
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ktf.yaml)")

--- a/internal/cmd/ktf/root.go
+++ b/internal/cmd/ktf/root.go
@@ -1,4 +1,4 @@
-package cmd
+package ktf
 
 import (
 	"github.com/spf13/cobra"

--- a/internal/cmd/ktf/vars.go
+++ b/internal/cmd/ktf/vars.go
@@ -1,4 +1,4 @@
-package cmd
+package ktf
 
 import "time"
 

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/kong/kubernetes-testing-framework/internal/cmd/ktf"
+
+func main() {
+	ktf.Execute()
+}

--- a/pkg/clusters/addons/kong/kong.go
+++ b/pkg/clusters/addons/kong/kong.go
@@ -205,17 +205,15 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 // caller will be providing their own ingress controller separately.
 func defaults() []string {
 	return []string{
-		// exposing the admin API and enabling raw HTTP for using it is convenient,
-		// but again keep in mind this is meant ONLY for testing scenarios and isn't secure.
+		// we configure a cluster network exposed admin API over HTTP with no auth for testing convenience,
+		// but again keep in mind this is meant ONLY for transient testing scenarios and isn't secure.
 		"--set", "proxy.http.nodePort=30080",
 		"--set", "admin.enabled=true",
 		"--set", "admin.http.enabled=true",
 		"--set", "admin.http.nodePort=32080",
 		"--set", "admin.tls.enabled=false",
+		"--set", "admin.type=ClusterIP",
 		"--set", "tls.enabled=false",
-		// this deployment expects a LoadBalancer Service provisioner (such as MetalLB).
-		"--set", "proxy.type=LoadBalancer",
-		"--set", "admin.type=LoadBalancer",
 		// we set up a few default ports for TCP and UDP proxy stream, it's up to
 		// test cases to use these how they see fit AND clean up after themselves.
 		"--set", "proxy.stream[0].containerPort=8888",
@@ -224,6 +222,8 @@ func defaults() []string {
 		"--set", "proxy.stream[1].servicePort=9999",
 		"--set", "proxy.stream[1].parameters[0]=udp",
 		"--set", "proxy.stream[1].parameters[1]=reuseport",
+		// the proxy expects a LoadBalancer Service provisioner (such as MetalLB).
+		"--set", "proxy.type=LoadBalancer",
 	}
 }
 

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -70,7 +70,7 @@ func (a *addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 	}
 
 	stderr := new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, "kubectl", args...) //nolint:gosec
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 
@@ -104,6 +104,7 @@ var (
 	defaultEndIP   = net.ParseIP("0.0.0.250")
 	metalManifest  = "https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml"
 	metalConfig    = "config"
+	secretKeyLen   = 128
 )
 
 // -----------------------------------------------------------------------------
@@ -144,7 +145,7 @@ func deployMetallbForKindCluster(kc *kubernetes.Clientset, kindClusterName, dock
 	}
 
 	// generate and deploy a metallb memberlist secret
-	secretKey := make([]byte, 128)
+	secretKey := make([]byte, secretKeyLen)
 	if _, err := rand.Read(secretKey); err != nil {
 		return err
 	}
@@ -196,7 +197,7 @@ func metallbDeployHack(clusterName string) error {
 	}
 
 	stderr := new(bytes.Buffer)
-	cmd := exec.Command("kubectl", deployArgs...) //nolint:gosec
+	cmd := exec.Command("kubectl", deployArgs...)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 
@@ -214,7 +215,7 @@ func metallbDeleteHack(clusterName string) error {
 	}
 
 	stderr := new(bytes.Buffer)
-	cmd := exec.Command("kubectl", deployArgs...) //nolint:gosec
+	cmd := exec.Command("kubectl", deployArgs...)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 

--- a/pkg/clusters/types/gke/builder.go
+++ b/pkg/clusters/types/gke/builder.go
@@ -1,0 +1,165 @@
+package gke
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	container "cloud.google.com/go/container/apiv1"
+	"github.com/blang/semver/v4"
+	"github.com/google/uuid"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+	"google.golang.org/api/transport"
+	containerpb "google.golang.org/genproto/googleapis/container/v1"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+// Builder generates clusters.Cluster objects backed by GKE given
+// provided configuration options.
+type Builder struct {
+	Name              string
+	project, location string
+	jsonCreds         []byte
+
+	addons         clusters.Addons
+	clusterVersion *semver.Version
+	majorMinor     string
+}
+
+// NewBuilder provides a new *Builder object.
+func NewBuilder(gkeJSONCredentials []byte, project, location string) *Builder {
+	return &Builder{
+		Name:      fmt.Sprintf("t-%s", uuid.NewString()),
+		project:   project,
+		location:  location,
+		jsonCreds: gkeJSONCredentials,
+		addons:    make(clusters.Addons),
+	}
+}
+
+// WithName indicates a custom name to use for the cluster.
+func (b *Builder) WithName(name string) *Builder {
+	b.Name = name
+	return b
+}
+
+// WithClusterVersion configures the Kubernetes cluster version for the Builder
+// to use when building the GKE cluster.
+func (b *Builder) WithClusterVersion(version semver.Version) *Builder {
+	b.clusterVersion = &version
+	return b
+}
+
+// WithClusterMinorVersion configures the Kubernetes cluster version according
+// to a provided Major and Minor version, but will automatically select the latest
+// patch version of that minor release (for convenience over the caller having to
+// know the entire version tag).
+func (b *Builder) WithClusterMinorVersion(major, minor uint64) *Builder {
+	b.majorMinor = fmt.Sprintf("%d.%d", major, minor)
+	return b
+}
+
+// Build creates and configures clients for a GKE-based Kubernetes clusters.Cluster.
+func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
+	// store the API options with the JSON credentials for auth
+	credsOpt := option.WithCredentialsJSON(b.jsonCreds)
+
+	// build the google api client to talk to GKE
+	mgrc, err := container.NewClusterManagerClient(ctx, credsOpt)
+	if err != nil {
+		return nil, err
+	}
+	defer mgrc.Close()
+
+	// build the google api IAM client to authenticate to the cluster
+	gcreds, err := transport.Creds(ctx, credsOpt, option.WithScopes(compute.CloudPlatformScope))
+	if err != nil {
+		return nil, err
+	}
+	oauthToken, err := gcreds.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// configure the cluster creation request
+	parent := fmt.Sprintf("projects/%s/locations/%s", b.project, b.location)
+	cluster := containerpb.Cluster{
+		Name:             b.Name,
+		InitialNodeCount: 1,
+	}
+	req := containerpb.CreateClusterRequest{Parent: parent, Cluster: &cluster}
+
+	// use any provided custom cluster version
+	if b.clusterVersion != nil && b.majorMinor != "" {
+		return nil, fmt.Errorf("options for full cluster version and partial are mutually exclusive")
+	}
+	if b.clusterVersion != nil {
+		cluster.InitialClusterVersion = b.clusterVersion.String()
+	}
+	if b.majorMinor != "" {
+		latestPatches, err := listLatestClusterPatchVersions(ctx, mgrc, b.project, b.location)
+		if err != nil {
+			return nil, err
+		}
+		v, ok := latestPatches[b.majorMinor]
+		if !ok {
+			return nil, fmt.Errorf("no available kubernetes version for %s", b.majorMinor)
+		}
+		cluster.InitialClusterVersion = v.String()
+	}
+
+	// create the GKE cluster asynchronously
+	_, err = mgrc.CreateCluster(ctx, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	// wait for cluster readiness
+	clusterReady := false
+	for !clusterReady {
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("failed to build cluster: %w", err)
+			}
+			return nil, fmt.Errorf("failed to build cluster: context completed")
+		default:
+			req := containerpb.GetClusterRequest{Name: fmt.Sprintf("%s/clusters/%s", parent, b.Name)}
+			cluster, err := mgrc.GetCluster(ctx, &req)
+			if err != nil {
+				if _, deleteErr := deleteCluster(ctx, mgrc, b.Name, b.project, b.location); deleteErr != nil {
+					return nil, fmt.Errorf("failed to retrieve cluster after building (%s), then failed to clean up: %w", err, deleteErr)
+				}
+				return nil, err
+			}
+			if cluster.Status == containerpb.Cluster_RUNNING {
+				clusterReady = true
+				break
+			}
+			time.Sleep(waitForClusterTick)
+		}
+	}
+
+	// get the restconfig and kubernetes client for the cluster
+	restCFG, k8s, err := clientForCluster(ctx, mgrc, oauthToken.AccessToken, b.Name, b.project, b.location)
+	if err != nil {
+		if _, deleteErr := deleteCluster(ctx, mgrc, b.Name, b.project, b.location); deleteErr != nil {
+			return nil, fmt.Errorf("failed to get cluster client (%s), then failed to clean up: %w", err, deleteErr)
+		}
+		return nil, err
+	}
+
+	return &gkeCluster{
+		name:      b.Name,
+		project:   b.project,
+		location:  b.location,
+		jsonCreds: b.jsonCreds,
+		client:    k8s,
+		cfg:       restCFG,
+		addons:    make(clusters.Addons),
+		l:         &sync.RWMutex{},
+	}, nil
+}

--- a/pkg/clusters/types/gke/cluster.go
+++ b/pkg/clusters/types/gke/cluster.go
@@ -1,0 +1,129 @@
+package gke
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	container "cloud.google.com/go/container/apiv1"
+	"google.golang.org/api/option"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+// -----------------------------------------------------------------------------
+// GKE Cluster
+// -----------------------------------------------------------------------------
+
+// gkeCluster is a clusters.Cluster implementation backed by Google Kubernetes Engine (GKE)
+type gkeCluster struct {
+	name      string
+	project   string
+	location  string
+	jsonCreds []byte
+	client    *kubernetes.Clientset
+	cfg       *rest.Config
+	addons    clusters.Addons
+	l         *sync.RWMutex
+}
+
+// -----------------------------------------------------------------------------
+// GKE Cluster - Cluster Implementation
+// -----------------------------------------------------------------------------
+
+func (c *gkeCluster) Name() string {
+	return c.name
+}
+
+func (c *gkeCluster) Type() clusters.Type {
+	return GKEClusterType
+}
+
+func (c *gkeCluster) Cleanup(ctx context.Context) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if os.Getenv(EnvKeepCluster) == "" {
+		credsOpt := option.WithCredentialsJSON(c.jsonCreds)
+		mgrc, err := container.NewClusterManagerClient(ctx, credsOpt)
+		if err != nil {
+			return err
+		}
+		defer mgrc.Close()
+
+		_, err = deleteCluster(ctx, mgrc, c.name, c.project, c.location)
+		return err
+	}
+
+	return nil
+}
+
+func (c *gkeCluster) Client() *kubernetes.Clientset {
+	return c.client
+}
+
+func (c *gkeCluster) Config() *rest.Config {
+	return c.cfg
+}
+
+func (c *gkeCluster) GetAddon(name clusters.AddonName) (clusters.Addon, error) {
+	c.l.RLock()
+	defer c.l.RUnlock()
+
+	for addonName, addon := range c.addons {
+		if addonName == name {
+			return addon, nil
+		}
+	}
+
+	return nil, fmt.Errorf("addon %s not found", name)
+}
+
+func (c *gkeCluster) ListAddons() []clusters.Addon {
+	c.l.RLock()
+	defer c.l.RUnlock()
+
+	addonList := make([]clusters.Addon, 0, len(c.addons))
+	for _, v := range c.addons {
+		addonList = append(addonList, v)
+	}
+
+	return addonList
+}
+
+func (c *gkeCluster) DeployAddon(ctx context.Context, addon clusters.Addon) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if _, ok := c.addons[addon.Name()]; ok {
+		return fmt.Errorf("addon component %s is already loaded into cluster %s", addon.Name(), c.Name())
+	}
+
+	if err := addon.Deploy(ctx, c); err != nil {
+		return err
+	}
+
+	c.addons[addon.Name()] = addon
+
+	return nil
+}
+
+func (c *gkeCluster) DeleteAddon(ctx context.Context, addon clusters.Addon) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if _, ok := c.addons[addon.Name()]; !ok {
+		return nil
+	}
+
+	if err := addon.Delete(ctx, c); err != nil {
+		return err
+	}
+
+	delete(c.addons, addon.Name())
+
+	return nil
+}

--- a/pkg/clusters/types/gke/utils.go
+++ b/pkg/clusters/types/gke/utils.go
@@ -1,0 +1,119 @@
+package gke
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	container "cloud.google.com/go/container/apiv1"
+	"github.com/blang/semver/v4"
+	containerpb "google.golang.org/genproto/googleapis/container/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// -----------------------------------------------------------------------------
+// Private Functions - Cluster Management
+// -----------------------------------------------------------------------------
+
+// deleteCluster deletes an existing GKE cluster.
+func deleteCluster(
+	ctx context.Context,
+	c *container.ClusterManagerClient,
+	name, project, location string,
+) (*containerpb.Operation, error) {
+	// tear down the cluster and return the teardown operation
+	fullname := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, name)
+	req := containerpb.DeleteClusterRequest{Name: fullname}
+	return c.DeleteCluster(ctx, &req)
+}
+
+// clientForCluster provides a *kubernetes.Clientset for a GKE cluster provided the cluster name
+// and an oauth token for the gcloud API. This client will only be valid for 1 hour.
+func clientForCluster(
+	ctx context.Context,
+	mgrc *container.ClusterManagerClient,
+	oauthToken, name, project, location string,
+) (*rest.Config, *kubernetes.Clientset, error) {
+	// pull the record of the cluster from the gke API
+	fullname := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, name)
+	getClusterReq := containerpb.GetClusterRequest{Name: fullname}
+	cluster, err := mgrc.GetCluster(ctx, &getClusterReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// decode the TLS data needed to communicate with the cluster securely
+	decodedClientCert, err := base64.StdEncoding.DecodeString(cluster.MasterAuth.ClientCertificate)
+	if err != nil {
+		return nil, nil, err
+	}
+	decodedClientKey, err := base64.StdEncoding.DecodeString(cluster.MasterAuth.ClientKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	decodedCA, err := base64.StdEncoding.DecodeString(cluster.MasterAuth.ClusterCaCertificate)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// generate the *rest.Config and kubernetes.Clientset
+	cfg := rest.Config{
+		BearerToken: oauthToken,
+		Host:        "https://" + cluster.Endpoint,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: false,
+			CertData: decodedClientCert,
+			KeyData:  decodedClientKey,
+			CAData:   decodedCA,
+		},
+	}
+	k, err := kubernetes.NewForConfig(&cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// perform a quick failfast validation that the client is actually useable
+	_, err = k.ServerVersion()
+	if err != nil {
+		return nil, nil, fmt.Errorf("configuration invalid: %w", err)
+	}
+
+	return &cfg, k, nil
+}
+
+// listLatestClusterPatchVersions provides a map which provides the semver (and api tag) of the latest
+// patch version for any particular major/minor release of Kubernetes on GKE.
+func listLatestClusterPatchVersions(ctx context.Context, c *container.ClusterManagerClient, project, location string) (map[string]semver.Version, error) {
+	// pull the container server config which includes all the available control plan and node versions
+	parent := fmt.Sprintf("projects/%s/locations/%s", project, location)
+	req := containerpb.GetServerConfigRequest{Name: parent}
+	resp, err := c.GetServerConfig(ctx, &req)
+	if err != nil {
+		return nil, err
+	}
+	availableVersions := resp.GetValidMasterVersions()
+
+	// find all valid versions and sort them newest to oldest
+	versionMap := make(map[string]semver.Version)
+	for _, version := range availableVersions {
+		version, err := semver.Parse(version)
+		if err != nil {
+			return nil, err
+		}
+
+		// the google cloud API does not include a filtration option to find only the latest
+		// patch versions for any particular major or minor version, so we reduce that ourselves.
+		majorMinor := fmt.Sprintf("%d.%d", version.Major, version.Minor)
+		if seenVersion, ok := versionMap[majorMinor]; ok {
+			if version.LT(seenVersion) {
+				continue
+			}
+		}
+
+		// if we made it here this is the latest patch version for the major/minor, store it.
+		versionMap[majorMinor] = version
+	}
+
+	return versionMap, nil
+}

--- a/pkg/clusters/types/gke/vars.go
+++ b/pkg/clusters/types/gke/vars.go
@@ -1,0 +1,26 @@
+package gke
+
+import (
+	"os"
+	"time"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+// -----------------------------------------------------------------------------
+// GKE Cluster - Vars
+// -----------------------------------------------------------------------------
+
+const (
+	// GKEClusterType indicates that the Kubernetes cluster was provisioned by Google Kubernetes Engine (GKE)
+	GKEClusterType clusters.Type = "gke"
+
+	// waitForClusterTick indicates the number of seconds to wait between cluster checks
+	// when deploying a new GKE cluster.
+	waitForClusterTick = time.Second * 3
+)
+
+var (
+	// EnvKeepCluster indicates whether the caller wants the cluster to remain after tests for manual inspection.
+	EnvKeepCluster = os.Getenv("GKE_KEEP_CLUSTER")
+)

--- a/pkg/clusters/types/kind/utils.go
+++ b/pkg/clusters/types/kind/utils.go
@@ -45,7 +45,7 @@ func createCluster(ctx context.Context, name string, extraArgs ...string) error 
 	args = append(args, extraArgs...)
 
 	stderr := new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, "kind", args...) //nolint:gosec
+	cmd := exec.CommandContext(ctx, "kind", args...)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {

--- a/pkg/utils/docker/docker.go
+++ b/pkg/utils/docker/docker.go
@@ -16,7 +16,7 @@ import (
 // InspectDockerContainer is a helper function that uses the local docker environment
 // provides the full container spec for a container present in that environment by name.
 func InspectDockerContainer(containerID string) (*types.ContainerJSON, error) {
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewEnvClient() //nolint:staticcheck
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/kong/fake_admin_api.go
+++ b/pkg/utils/kong/fake_admin_api.go
@@ -12,6 +12,8 @@ import (
 // FakeAdminAPIServer - Public Types
 // -----------------------------------------------------------------------------
 
+const maxMocks = 1000
+
 // AdminAPIResponse represents an HTTP response from the Kong Admin API
 type AdminAPIResponse struct {
 	Status   int
@@ -38,7 +40,7 @@ type FakeAdminAPIServer struct {
 // that requires a *kong.Client or otherwise needs to communicate with the Kong Admin API.
 func NewFakeAdminAPIServer() (*FakeAdminAPIServer, error) {
 	// start up the fake admin api server
-	mocks := make(chan AdminAPIResponse, 1000)
+	mocks := make(chan AdminAPIResponse, maxMocks)
 	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case override := <-mocks:
@@ -49,7 +51,7 @@ func NewFakeAdminAPIServer() (*FakeAdminAPIServer, error) {
 
 			// for most tests you'll want to buffer several mock responses and then run through your requests in the same order
 			w.WriteHeader(override.Status)
-			fmt.Fprintf(w, string(override.Body))
+			fmt.Fprint(w, string(override.Body))
 		default:
 			// by default the response behavior is to provide a minimal root configuration for the server
 			w.WriteHeader(http.StatusOK)
@@ -60,7 +62,6 @@ func NewFakeAdminAPIServer() (*FakeAdminAPIServer, error) {
 				}
 			}`)
 		}
-		return
 	}))
 
 	// generate an http client for the fake admin api server

--- a/pkg/utils/kubernetes/generators/ingress.go
+++ b/pkg/utils/kubernetes/generators/ingress.go
@@ -3,7 +3,9 @@ package generators
 import (
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // -----------------------------------------------------------------------------
@@ -34,6 +36,37 @@ func NewIngressForService(path string, annotations map[string]string, s *corev1.
 												Number: s.Spec.Ports[0].Port,
 											},
 										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// NewLegacyIngressForService provides a basic and opinionated *netv1beta1.Ingress object for the provided *corev1.Service to expose it via an ingress controller for testing purposes.
+func NewLegacyIngressForService(path string, annotations map[string]string, s *corev1.Service) *netv1beta1.Ingress {
+	pathPrefix := netv1beta1.PathTypePrefix
+	return &netv1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        s.Name,
+			Annotations: annotations,
+		},
+		Spec: netv1beta1.IngressSpec{
+			Rules: []netv1beta1.IngressRule{
+				{
+					IngressRuleValue: netv1beta1.IngressRuleValue{
+						HTTP: &netv1beta1.HTTPIngressRuleValue{
+							Paths: []netv1beta1.HTTPIngressPath{
+								{
+									Path:     path,
+									PathType: &pathPrefix,
+									Backend: netv1beta1.IngressBackend{
+										ServiceName: s.Name,
+										ServicePort: intstr.FromInt(int(s.Spec.Ports[0].Port)),
 									},
 								},
 							},

--- a/pkg/utils/kubernetes/generators/kubeconfig.go
+++ b/pkg/utils/kubernetes/generators/kubeconfig.go
@@ -1,0 +1,46 @@
+package generators
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// NewKubeConfigForRestConfig provides the bytes for a kubeconfig file for use
+// by kubectl or helm given a valid *rest.Config for the target cluster.
+func NewKubeConfigForRestConfig(name string, restcfg *rest.Config) ([]byte, error) {
+	clientcfg := NewClientConfigForRestConfig(name, restcfg)
+	return clientcmd.Write(*clientcfg)
+}
+
+// NewClientConfigForRestConfig provides the *clientcmdapi.Config for a cluster
+// given a valid *rest.Config for the target cluster.
+func NewClientConfigForRestConfig(name string, restcfg *rest.Config) *clientcmdapi.Config {
+	// configure the cluster
+	cluster := clientcmdapi.NewCluster()
+	cluster.CertificateAuthorityData = restcfg.CAData
+	cluster.Server = restcfg.Host
+
+	// configure the authdata
+	authinfo := clientcmdapi.NewAuthInfo()
+	authinfo.AuthProvider = restcfg.AuthProvider
+	authinfo.ClientCertificateData = restcfg.CertData
+	authinfo.ClientKeyData = restcfg.KeyData
+	authinfo.Username = restcfg.Username
+	authinfo.Password = restcfg.Password
+	authinfo.Token = restcfg.BearerToken
+
+	// configure the current context
+	context := clientcmdapi.NewContext()
+	context.Cluster = name
+	context.AuthInfo = name
+
+	// generate the configuration
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters[name] = cluster
+	cfg.Contexts[name] = context
+	cfg.AuthInfos[name] = authinfo
+	cfg.CurrentContext = name
+
+	return cfg
+}

--- a/pkg/utils/networking/networking.go
+++ b/pkg/utils/networking/networking.go
@@ -10,19 +10,24 @@ import (
 // Public Functions - Helper
 // -----------------------------------------------------------------------------
 
+const (
+	ipv4len   = 16
+	ipv4bytes = 4
+)
+
 // ConvertIPv4ToUint32 converts an IPv4 net.IP to a uint32
 // FIXME: this does nothing to protect the caller from bad input yet
 func ConvertIPv4ToUint32(ip net.IP) uint32 {
-	if len(ip) == 16 {
+	if len(ip) == ipv4len {
 		return binary.BigEndian.Uint32(ip[12:16])
 	}
 	return binary.BigEndian.Uint32(ip)
 }
 
-// ConvertIPv4ToUint32 converts an IPv4 net.IP to a uint32
+// ConvertUint32ToIPv4 converts an IPv4 net.IP to a uint32
 // FIXME: this does nothing to protect the caller from bad input yet
 func ConvertUint32ToIPv4(i uint32) net.IP {
-	ip := make(net.IP, 4)
+	ip := make(net.IP, ipv4bytes)
 	binary.BigEndian.PutUint32(ip, i)
 	return ip
 }

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -1,0 +1,140 @@
+//+build e2e_tests
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/gke"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+)
+
+const (
+	gkeCredsVar    = "GOOGLE_APPLICATION_CREDENTIALS"
+	gkeProjectVar  = "GOOGLE_PROJECT"
+	gkeLocationVar = "GOOGLE_LOCATION"
+)
+
+var (
+	gkeCreds    = os.Getenv(gkeCredsVar)
+	gkeProject  = os.Getenv(gkeProjectVar)
+	gkeLocation = os.Getenv(gkeLocationVar)
+)
+
+func TestGKECluster(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*15)
+	defer cancel()
+
+	t.Log("configuring GKE cloud environment for tests")
+	require.NotEmpty(t, gkeCredsVar, "%s not set", gkeCredsVar)
+	require.NotEmpty(t, gkeProject, "%s not set", gkeProjectVar)
+	require.NotEmpty(t, gkeLocation, "%s not set", gkeLocationVar)
+
+	t.Logf("configuring the GKE cluster PROJECT=(%s) LOCATION=(%s)", gkeProject, gkeLocation)
+	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation)
+	builder.WithClusterMinorVersion(1, 17)
+
+	t.Logf("building cluster %s (this can take some time)", builder.Name)
+	cluster, err := builder.Build(ctx)
+	require.NoError(t, err)
+
+	t.Logf("setting up cleanup for cluster %s", cluster.Name())
+	defer func() {
+		assert.NoError(t, cluster.Cleanup(ctx))
+	}()
+
+	t.Log("verifying that the cluster can be communicated with")
+	version, err := cluster.Client().ServerVersion()
+	require.NoError(t, err)
+	t.Logf("server version found: %s", version)
+
+	t.Log("loading the gke cluster into a testing environment and deploying kong addon")
+	env, err := environments.NewBuilder().WithAddons(kong.New()).WithExistingCluster(cluster).Build(ctx)
+	require.NoError(t, err)
+
+	t.Log("waiting for addons to be ready")
+	require.NoError(t, <-env.WaitForReady(ctx))
+
+	t.Log("verifying that the kong addon deployed both proxy and controller")
+	kongAddon, err := env.Cluster().GetAddon("kong")
+	require.NoError(t, err)
+	kongAddonRaw, ok := kongAddon.(*kong.Addon)
+	require.True(t, ok)
+	proxyURL, err := kongAddonRaw.ProxyURL(ctx, env.Cluster())
+	require.NoError(t, err)
+	kongDeployment, err := env.Cluster().Client().AppsV1().Deployments(kongAddonRaw.Namespace()).Get(ctx, "ingress-controller-kong", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, kongDeployment.Spec.Template.Spec.Containers, 2)
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[0].Name, "ingress-controller")
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[1].Name, "proxy")
+
+	t.Log("deploying a test deployment to ensure the environment's cluster is working")
+	container := generators.NewContainer("httpbin", "docker.io/kennethreitz/httpbin", 80)
+	deployment := generators.NewDeploymentForContainer(container)
+	deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("verifying the underlying pods deploy successfully")
+	require.Eventually(t, func() bool {
+		deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Get(ctx, deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
+	}, time.Minute*1, time.Second*1)
+
+	t.Logf("exposing deployment %s via service", deployment.Name)
+	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("creating an ingress for service %s with ingress.class kong", service.Name)
+	ingress := generators.NewLegacyIngressForService("/httpbin", map[string]string{
+		"kubernetes.io/ingress.class": "kong",
+		"konghq.com/strip-path":       "true",
+	}, service)
+	ingress, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(corev1.NamespaceDefault).Create(ctx, ingress, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("waiting for ingress status update to validate that the kong controller is functioning")
+	require.Eventually(t, func() bool {
+		ingress, err = env.Cluster().Client().NetworkingV1beta1().Ingresses(corev1.NamespaceDefault).Get(ctx, ingress.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return len(ingress.Status.LoadBalancer.Ingress) > 0
+	}, time.Minute*1, time.Second*1)
+
+	t.Logf("accessing the deployment via ingress %s to validate that the kong proxy is functioning", ingress.Name)
+	httpc := http.Client{Timeout: time.Second * 3}
+	require.Eventually(t, func() bool {
+		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL))
+		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			b := new(bytes.Buffer)
+			n, err := b.ReadFrom(resp.Body)
+			require.NoError(t, err)
+			require.True(t, n > 0)
+			return strings.Contains(b.String(), "<title>httpbin.org</title>")
+		}
+		return false
+	}, time.Minute*1, time.Second*1)
+}

--- a/test/integration/kind_version_test.go
+++ b/test/integration/kind_version_test.go
@@ -31,10 +31,7 @@ func TestKindClusterOlderVersion(t *testing.T) {
 	t.Log("waiting for cluster api to become usable")
 	require.Eventually(t, func() bool {
 		_, err := cluster.Client().ServerVersion()
-		if err != nil {
-			return false
-		}
-		return true
+		return err == nil
 	}, time.Minute*1, time.Second*1)
 
 	t.Logf("verifying that the created cluster is kubernetes version %s", clusterVersion)
@@ -60,10 +57,7 @@ func TestKindClusterNewerVersion(t *testing.T) {
 	t.Log("waiting for cluster api to become usable")
 	require.Eventually(t, func() bool {
 		_, err := cluster.Client().ServerVersion()
-		if err != nil {
-			return false
-		}
-		return true
+		return err == nil
 	}, time.Minute*1, time.Second*1)
 
 	t.Logf("verifying that the created cluster is kubernetes version %s", clusterVersion)

--- a/test/integration/metallb_test.go
+++ b/test/integration/metallb_test.go
@@ -61,20 +61,20 @@ func TestEnvironmentWithMetallb(t *testing.T) {
 	require.Len(t, waitForObjects, 0)
 	require.True(t, ready)
 
-	t.Logf("verifying that the kong proxy admin service %s gets provisioned an IP address by metallb", kongaddon.DefaultAdminServiceName)
-	adminURL, err := kong.ProxyAdminURL(ctx, env.Cluster())
+	t.Logf("verifying that the kong proxy service %s gets provisioned an IP address by metallb", kongaddon.DefaultProxyServiceName)
+	proxyURL, err := kong.ProxyURL(ctx, env.Cluster())
 	require.NoError(t, err)
-	require.NotNil(t, adminURL)
+	require.NotNil(t, proxyURL)
 
-	t.Logf("found url %s for proxy admin, now verifying it is routable", adminURL)
+	t.Logf("found url %s for proxy, now verifying it is routable", proxyURL)
 	httpc := http.Client{Timeout: time.Second * 3}
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(adminURL.String())
+		resp, err := httpc.Get(proxyURL.String())
 		if err != nil {
 			return false
 		}
 		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
+		return resp.StatusCode == http.StatusNotFound
 	}, time.Minute*1, time.Second*1)
 
 	t.Log("cleaning up the metallb addon")

--- a/test/integration/postgres_test.go
+++ b/test/integration/postgres_test.go
@@ -37,19 +37,19 @@ func TestKongWithPostgresDBMode(t *testing.T) {
 	t.Log("waiting for environment to be ready")
 	require.NoError(t, <-env.WaitForReady(ctx))
 
-	t.Logf("verifying that the kong proxy admin service %s gets provisioned an IP address by metallb", kongaddon.DefaultAdminServiceName)
-	adminURL, err := kong.ProxyAdminURL(ctx, env.Cluster())
+	t.Logf("verifying that the kong proxy service %s gets provisioned an IP address by metallb", kongaddon.DefaultProxyServiceName)
+	proxyURL, err := kong.ProxyURL(ctx, env.Cluster())
 	require.NoError(t, err)
-	require.NotNil(t, adminURL)
+	require.NotNil(t, proxyURL)
 
-	t.Logf("found url %s for proxy admin, now verifying it is routable", adminURL)
+	t.Logf("found url %s for proxy, now verifying it is routable", proxyURL)
 	httpc := http.Client{Timeout: time.Second * 3}
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(adminURL.String())
+		resp, err := httpc.Get(proxyURL.String())
 		if err != nil {
 			return false
 		}
 		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
+		return resp.StatusCode == http.StatusNotFound
 	}, time.Minute*1, time.Second*1)
 }


### PR DESCRIPTION
Resolves https://github.com/Kong/kubernetes-testing-framework/issues/32
Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1095

Additionally:
- adds `golangci-lint` checking to the CI
- adds e2e tests & configures them as a CI release wf requirement
- fully `internal/`izes CLI components