### PR TITLE
[feat] legacy ingress utils

### DIFF
--- a/pkg/clusters/utils.go
+++ b/pkg/clusters/utils.go
@@ -1,0 +1,77 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
+	netv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DeployIngress is a helper and function to deploy an Ingress object to a cluster handling
+// the version of the Ingress object for the caller so they don't have to.
+// TODO: once we stop supporting old Kubernetes versions <1.19 we can remove this.
+func DeployIngress(ctx context.Context, c Cluster, namespace string, ingress runtime.Object) (err error) {
+	switch obj := ingress.(type) {
+	case *netv1.Ingress:
+		_, err = c.Client().NetworkingV1().Ingresses(namespace).Create(ctx, obj, metav1.CreateOptions{})
+	case *netv1beta1.Ingress:
+		_, err = c.Client().NetworkingV1beta1().Ingresses(namespace).Create(ctx, obj, metav1.CreateOptions{})
+	case *extv1beta1.Ingress:
+		_, err = c.Client().ExtensionsV1beta1().Ingresses(namespace).Create(ctx, obj, metav1.CreateOptions{})
+	default:
+		err = fmt.Errorf("%T is not a supported ingress type", ingress)
+	}
+	return
+}
+
+// DeleteIngress is a helper and function to delete an Ingress object to a cluster handling
+// the version of the Ingress object for the caller so they don't have to.
+// TODO: once we stop supporting old Kubernetes versions <1.19 we can remove this.
+func DeleteIngress(ctx context.Context, c Cluster, namespace string, ingress runtime.Object) (err error) {
+	switch obj := ingress.(type) {
+	case *netv1.Ingress:
+		err = c.Client().NetworkingV1().Ingresses(namespace).Delete(ctx, obj.Name, metav1.DeleteOptions{})
+	case *netv1beta1.Ingress:
+		err = c.Client().NetworkingV1beta1().Ingresses(namespace).Delete(ctx, obj.Name, metav1.DeleteOptions{})
+	case *extv1beta1.Ingress:
+		err = c.Client().ExtensionsV1beta1().Ingresses(namespace).Delete(ctx, obj.Name, metav1.DeleteOptions{})
+	default:
+		err = fmt.Errorf("%T is not a supported ingress type", ingress)
+	}
+	return
+}
+
+// GetIngressLoadbalancerStatus is a partner to the above DeployIngress function which will
+// given an Ingress object provided by the caller determine the version and pull a fresh copy
+// of the current LoadBalancerStatus for that Ingress object without the caller needing to be
+// aware of which version of Ingress they're using.
+// TODO: once we stop supporting old Kubernetes versions <1.19 we can remove this.
+func GetIngressLoadbalancerStatus(ctx context.Context, c Cluster, namespace string, ingress runtime.Object) (*corev1.LoadBalancerStatus, error) {
+	switch obj := ingress.(type) {
+	case *netv1.Ingress:
+		refresh, err := c.Client().NetworkingV1().Ingresses(namespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return &refresh.Status.LoadBalancer, nil
+	case *netv1beta1.Ingress:
+		refresh, err := c.Client().NetworkingV1beta1().Ingresses(namespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return &refresh.Status.LoadBalancer, nil
+	case *extv1beta1.Ingress:
+		refresh, err := c.Client().ExtensionsV1beta1().Ingresses(namespace).Get(ctx, obj.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return &refresh.Status.LoadBalancer, nil
+	default:
+		return nil, fmt.Errorf("%T is not a supported ingress type", ingress)
+	}
+}

--- a/pkg/utils/kubernetes/generators/ingress.go
+++ b/pkg/utils/kubernetes/generators/ingress.go
@@ -1,16 +1,27 @@
 package generators
 
 import (
+	"github.com/blang/semver/v4"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // -----------------------------------------------------------------------------
 // Public Functions - netv1.Ingress Helpers
 // -----------------------------------------------------------------------------
+
+// NewIngressForServiceWithClusterVersion provides an Ingress record for the provided service, but uses a provided
+// Kubernetes cluster version to determine which Ingress version to provide (provides latest available for release).
+func NewIngressForServiceWithClusterVersion(kubernetesVersion semver.Version, path string, annotations map[string]string, s *corev1.Service) runtime.Object {
+	if kubernetesVersion.Major < 2 && kubernetesVersion.Minor < 19 {
+		return NewLegacyIngressForService(path, annotations, s)
+	}
+	return NewIngressForService(path, annotations, s)
+}
 
 // NewIngressForService provides a basic and opinionated *netv1.Ingress object for the provided *corev1.Service to expose it via an ingress controller for testing purposes.
 func NewIngressForService(path string, annotations map[string]string, s *corev1.Service) *netv1.Ingress {


### PR DESCRIPTION
- feat: add a generator which determines ing version
- feat: add utils to handle ing version auto on old clusters

Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1614