### PR TITLE
feat: add version check to cluster interface

### DIFF
--- a/pkg/clusters/cluster.go
+++ b/pkg/clusters/cluster.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"context"
 
+	"github.com/blang/semver/v4"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -21,6 +22,9 @@ type Cluster interface {
 
 	// Type indicates the type of Kubernetes Cluster (e.g. Kind, GKE, e.t.c.)
 	Type() Type
+
+	// Version indicates the Kubernetes server version of the cluster.
+	Version() (semver.Version, error)
 
 	// Client is the configured *kubernetes.Clientset which can be used to access the Cluster's API
 	Client() *kubernetes.Clientset

--- a/pkg/clusters/types/gke/cluster.go
+++ b/pkg/clusters/types/gke/cluster.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	container "cloud.google.com/go/container/apiv1"
+	"github.com/blang/semver/v4"
 	"google.golang.org/api/option"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -87,6 +89,14 @@ func (c *gkeCluster) Name() string {
 
 func (c *gkeCluster) Type() clusters.Type {
 	return GKEClusterType
+}
+
+func (c *gkeCluster) Version() (semver.Version, error) {
+	versionInfo, err := c.Client().ServerVersion()
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return semver.Parse(strings.TrimPrefix(versionInfo.String(), "v"))
 }
 
 func (c *gkeCluster) Cleanup(ctx context.Context) error {

--- a/pkg/clusters/types/kind/cluster.go
+++ b/pkg/clusters/types/kind/cluster.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 )
 
@@ -53,6 +55,14 @@ func (c *kindCluster) Name() string {
 
 func (c *kindCluster) Type() clusters.Type {
 	return KindClusterType
+}
+
+func (c *kindCluster) Version() (semver.Version, error) {
+	versionInfo, err := c.Client().ServerVersion()
+	if err != nil {
+		return semver.Version{}, err
+	}
+	return semver.Parse(strings.TrimPrefix(versionInfo.String(), "v"))
 }
 
 func (c *kindCluster) Cleanup(ctx context.Context) error {

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -70,12 +69,10 @@ func TestGKECluster(t *testing.T) {
 	require.NoError(t, <-env.WaitForReady(ctx))
 
 	t.Log("validating kubernetes cluster version")
-	versionInfo, err := env.Cluster().Client().ServerVersion()
+	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	kubernetesVersion, err := semver.Parse(strings.TrimPrefix(versionInfo.String(), "v"))
-	require.NoError(t, err)
-	require.Equal(t, 1, kubernetesVersion.Major)
-	require.Equal(t, 17, kubernetesVersion.Minor)
+	require.Equal(t, uint64(1), kubernetesVersion.Major)
+	require.Equal(t, uint64(17), kubernetesVersion.Minor)
 
 	t.Log("verifying that the kong addon deployed both proxy and controller")
 	kongAddon, err := env.Cluster().GetAddon("kong")

--- a/test/integration/kind_version_test.go
+++ b/test/integration/kind_version_test.go
@@ -35,9 +35,10 @@ func TestKindClusterOlderVersion(t *testing.T) {
 	}, time.Minute*1, time.Second*1)
 
 	t.Logf("verifying that the created cluster is kubernetes version %s", clusterVersion)
-	serverVersion, err := cluster.Client().ServerVersion()
+	serverVersion, err := cluster.Version()
 	require.NoError(t, err)
-	assert.Equal(t, "v"+clusterVersion.String(), serverVersion.String())
+	require.Equal(t, clusterVersion.String(), serverVersion.String())
+	require.True(t, clusterVersion.EQ(serverVersion))
 }
 
 func TestKindClusterNewerVersion(t *testing.T) {
@@ -61,7 +62,8 @@ func TestKindClusterNewerVersion(t *testing.T) {
 	}, time.Minute*1, time.Second*1)
 
 	t.Logf("verifying that the created cluster is kubernetes version %s", clusterVersion)
-	serverVersion, err := cluster.Client().ServerVersion()
+	serverVersion, err := cluster.Version()
 	require.NoError(t, err)
-	assert.Equal(t, "v"+clusterVersion.String(), serverVersion.String())
+	require.Equal(t, clusterVersion.String(), serverVersion.String())
+	require.True(t, clusterVersion.EQ(serverVersion))
 }


### PR DESCRIPTION
Adds a convenience method to get the cluster version, and requires that all cluster implementations implement one.

Also fixes an issue in the release tests with version comparisons.