### PR TITLE
feat: ktf labels gke clusters

### DIFF
--- a/pkg/clusters/types/gke/utils.go
+++ b/pkg/clusters/types/gke/utils.go
@@ -76,12 +76,6 @@ func clientForCluster(
 		return nil, nil, err
 	}
 
-	// perform a quick failfast validation that the client is actually useable
-	_, err = k.ServerVersion()
-	if err != nil {
-		return nil, nil, fmt.Errorf("configuration invalid: %w", err)
-	}
-
 	return &cfg, k, nil
 }
 

--- a/pkg/clusters/types/gke/vars.go
+++ b/pkg/clusters/types/gke/vars.go
@@ -12,6 +12,10 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
+	// GKECreateLabel is the name of the label which be added to any cluster created with KTF and
+	// indicates which Google Cloud IAM Service Account created the cluster.
+	GKECreateLabel = "ktf_created_by"
+
 	// GKEClusterType indicates that the Kubernetes cluster was provisioned by Google Kubernetes Engine (GKE)
 	GKEClusterType clusters.Type = "gke"
 


### PR DESCRIPTION
This patch adds a label which makes it easy to identify when a GKE cluster was created by KTF, and for convenience the `client_id` of the IAM service account which performed the original creation.

This also removes a version check when creating the k8s client, as new use cases emerge that want to build the client async to the cluster creation and so the version check isn't appropriate.

Supports https://github.com/Kong/kubernetes-ingress-controller/issues/1627
Required By https://github.com/Kong/kubernetes-ingress-controller/pull/1631