### PR TITLE
fix: kong addon deployment idemopotence

### DIFF
--- a/pkg/clusters/addons/kong/kong.go
+++ b/pkg/clusters/addons/kong/kong.go
@@ -112,7 +112,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 
 	// ensure the repo is added
 	stderr := new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, "helm", "--kubeconfig", kubeconfig.Name(), "repo", "add", "kong", KongHelmRepoURL) //nolint:gosec
+	cmd := exec.CommandContext(ctx, "helm", "--kubeconfig", kubeconfig.Name(), "repo", "add", "--force-update", "kong", KongHelmRepoURL) //nolint:gosec
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {

--- a/pkg/clusters/addons/kong/kong.go
+++ b/pkg/clusters/addons/kong/kong.go
@@ -110,7 +110,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	}
 	defer os.Remove(kubeconfig.Name())
 
-	// ensure the repo is added
+	// ensure the repo exists
 	stderr := new(bytes.Buffer)
 	cmd := exec.CommandContext(ctx, "helm", "--kubeconfig", kubeconfig.Name(), "repo", "add", "--force-update", "kong", KongHelmRepoURL) //nolint:gosec
 	cmd.Stdout = io.Discard


### PR DESCRIPTION
At times the repo add command might throw an error
even if ultimately the repo is already there.

This patch adds the `--force-overwrite` options when
adding the kong repo to update it to the latest value
regardless of whether or not it already existed.

Resolves https://github.com/Kong/kubernetes-testing-framework/issues/80