### PR TITLE
feat: add utils for generating test namespaces

### DIFF
--- a/pkg/utils/kubernetes/generators/labels.go
+++ b/pkg/utils/kubernetes/generators/labels.go
@@ -1,0 +1,12 @@
+package generators
+
+// -----------------------------------------------------------------------------
+// Resource Labels
+// -----------------------------------------------------------------------------
+
+const (
+	// TestResourceLabel is a label used on any resources to indicate that they
+	// were created as part of a testing run and can be cleaned up in bulk based
+	// on the value provided to the label.
+	TestResourceLabel = "created-by-ktf"
+)

--- a/pkg/utils/kubernetes/generators/transient.go
+++ b/pkg/utils/kubernetes/generators/transient.go
@@ -1,0 +1,78 @@
+package generators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+// GenerateNamespace creates a transient testing namespace given the cluster to create
+// it on and a creator ID. The namespace will be given a UUID for a name, and the creatorID
+// will be applied to the TestResourceLabel for automated cleanup.
+func GenerateNamespace(ctx context.Context, cluster clusters.Cluster, creatorID string) (*corev1.Namespace, error) {
+	if creatorID == "" {
+		return nil, fmt.Errorf(`empty string "" is not a valid creator ID`)
+	}
+
+	name := uuid.NewString()
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				TestResourceLabel: creatorID,
+			},
+		},
+	}
+
+	return cluster.Client().CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+}
+
+// CleanupGeneratedResources cleans up all resources created by the given creator ID.
+func CleanupGeneratedResources(ctx context.Context, cluster clusters.Cluster, creatorID string) error {
+	if creatorID == "" {
+		return fmt.Errorf(`empty string "" is not a valid creator ID`)
+	}
+
+	listOpts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", TestResourceLabel, creatorID),
+	}
+
+	namespaceList, err := cluster.Client().CoreV1().Namespaces().List(ctx, listOpts)
+	if err != nil {
+		return err
+	}
+
+	namespacesToCleanup := make(map[string]*corev1.Namespace)
+	for i := 0; i < len(namespaceList.Items); i++ {
+		namespace := &(namespaceList.Items[i])
+		namespacesToCleanup[namespace.Name] = namespace
+	}
+
+	for len(namespacesToCleanup) > 0 {
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("context completed with error while waiting for cleanup: %w", err)
+			}
+			return fmt.Errorf("context completed while waiting for cleanup")
+		default:
+			for _, namespace := range namespaceList.Items {
+				if err := cluster.Client().CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{}); err != nil {
+					if errors.IsNotFound(err) {
+						delete(namespacesToCleanup, namespace.Name)
+					} else {
+						return fmt.Errorf("failed to delete namespace resource %s: %w", namespace.Name, err)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/test/integration/generators_test.go
+++ b/test/integration/generators_test.go
@@ -1,0 +1,122 @@
+//+build integration_tests
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	httpbinWait = time.Minute * 2
+	waitTick    = time.Second
+)
+
+func TestGenerators(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Log("creating a test environment to test generators")
+	env, err := environments.NewBuilder().Build(ctx)
+	require.NoError(t, err)
+
+	t.Log("waiting for the test environment to be ready")
+	require.NoError(t, <-env.WaitForReady(ctx))
+
+	t.Log("configuring 3 unique creators for namespace generation with different quotas")
+	creator1, creator1NamespaceCount := uuid.NewString(), 5
+	creator2, creator2NamespaceCount := uuid.NewString(), 2
+	creator3, creator3NamespaceCount := uuid.NewString(), 1
+	testingNamespaces := make(map[string][]*corev1.Namespace)
+
+	t.Logf("creating %d namespaces for creator ID 1", creator1NamespaceCount)
+	for i := 1; i < creator1NamespaceCount; i++ {
+		testingNamespace, err := generators.GenerateNamespace(ctx, env.Cluster(), creator1)
+		require.NoError(t, err)
+		testingNamespaces[creator1] = append(testingNamespaces[creator1], testingNamespace)
+	}
+
+	t.Logf("creating %d namespaces for creator ID 2", creator2NamespaceCount)
+	for i := 1; i < creator2NamespaceCount; i++ {
+		testingNamespace, err := generators.GenerateNamespace(ctx, env.Cluster(), creator2)
+		require.NoError(t, err)
+		testingNamespaces[creator2] = append(testingNamespaces[creator2], testingNamespace)
+	}
+
+	t.Logf("creating %d namespaces for creator ID 3", creator3NamespaceCount)
+	for i := 1; i < creator3NamespaceCount; i++ {
+		testingNamespace, err := generators.GenerateNamespace(ctx, env.Cluster(), creator3)
+		require.NoError(t, err)
+		testingNamespaces[creator3] = append(testingNamespaces[creator3], testingNamespace)
+	}
+
+	t.Logf("deploying a testing pod in each namespace and verifying they all deploy properly")
+	for _, namespaces := range testingNamespaces {
+		for _, namespace := range namespaces {
+			container := generators.NewContainer("httpbin", "kennethreitz/httpbin", 80)
+			deployment := generators.NewDeploymentForContainer(container)
+			_, err := env.Cluster().Client().AppsV1().Deployments(namespace.Name).Create(ctx, deployment, metav1.CreateOptions{})
+			require.NoError(t, err)
+		}
+		for _, namespace := range namespaces {
+			require.Eventually(t, func() bool {
+				deployment, err := env.Cluster().Client().AppsV1().Deployments(namespace.Name).Get(ctx, "httpbin", metav1.GetOptions{})
+				require.NoError(t, err)
+				return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
+			}, httpbinWait, waitTick)
+		}
+	}
+
+	t.Log("performing generated resource cleanup for creator ID 3")
+	require.NoError(t, generators.CleanupGeneratedResources(ctx, env.Cluster(), creator3))
+
+	t.Log("verifying that creator ID 3's namespaces were all removed from the cluster")
+	for _, namespace := range testingNamespaces[creator3] {
+		_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		require.Error(t, err)
+		require.True(t, errors.IsNotFound(err))
+	}
+
+	t.Log("verifying that the other creator ID's namespaces were left alone")
+	for _, namespace := range append(testingNamespaces[creator1], testingNamespaces[creator2]...) {
+		namespace, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Nil(t, namespace.DeletionTimestamp)
+	}
+
+	t.Log("performing generated resource cleanup for creator ID 1")
+	require.NoError(t, generators.CleanupGeneratedResources(ctx, env.Cluster(), creator1))
+
+	t.Log("verifying that creator ID 1's namespaces were all removed from the cluster")
+	for _, namespace := range testingNamespaces[creator1] {
+		_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		require.Error(t, err)
+		require.True(t, errors.IsNotFound(err))
+	}
+
+	t.Log("verifying that the other creator ID's namespaces were left alone")
+	for _, namespace := range testingNamespaces[creator2] {
+		namespace, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Nil(t, namespace.DeletionTimestamp)
+	}
+
+	t.Log("performing generated resource cleanup for creator ID 2")
+	require.NoError(t, generators.CleanupGeneratedResources(ctx, env.Cluster(), creator2))
+
+	t.Log("verifying that creator ID 2's namespaces were all removed from the cluster")
+	for _, namespace := range testingNamespaces[creator2] {
+		_, err := env.Cluster().Client().CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		require.Error(t, err)
+		require.True(t, errors.IsNotFound(err))
+	}
+}


### PR DESCRIPTION
This patch adds some tooling which will help provide more isolation and automated cleanup of testing resources for test suites implementing KTF clusters.

Resolves https://github.com/Kong/kubernetes-testing-framework/issues/17