### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,68 @@
+name: 🐞 Bug
+description: Something is not working as indended.
+labels: [bug]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+    placeholder: |
+      When I do <X>, <Y> happens and I see the error message attached below:
+      ```...```
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+    placeholder: When I do <X>, <Z> should happen instead.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Kong Ingress Controller version
+    description: |
+      example: v1.3.1
+    placeholder: 'Please put the KIC version here.'
+    render: shell
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Kubernetes version
+    description: |
+      example:
+        Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:28:09Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+        Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+    placeholder: 'Please put the Kubernetes version here.'
+    render: shell
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -39,10 +39,10 @@ body:
     required: false
 - type: textarea
   attributes:
-    label: Kong Ingress Controller version
+    label: Kong Kubernetes Testing Framework Version
     description: |
-      example: v1.3.1
-    placeholder: 'Please put the KIC version here.'
+      example: v0.6.1
+    placeholder: 'Please put the KTF version here.'
     render: shell
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,48 @@
+name: ✨ Enhancement / Feature / Task
+description: Some feature is missing or incomplete.
+labels: [enhancement]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Problem Statement
+    description: Without specifying a solution, describe what the project is missing today.
+    placeholder: |
+      The rotating project logo has a fixed size and color.
+      There is no way to make it larger and more shiny.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Proposed Solution
+    description: Describe the proposed solution to the problem above.
+    placeholder: |
+      - Implement 2 new flags CLI: ```--logo-color=FFD700``` and ```--logo-size=100```
+      - Let these flags control the size of the rotating project logo.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional information
+    placeholder: |
+      We considered adjusting the logo size to the phase of the moon, but there was no
+      reliable data source in air-gapped environments.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Acceptance Criteria
+    placeholder: |
+      - [ ] As a user, I can control the size of the rotating logo using a CLI flag.
+      - [ ] As a user, I can control the color of the rotating logo using a CLI flag.
+      - [ ] Defaults are reasonably set.
+      - [ ] New settings are appropriately documented.
+      - [ ] No breaking change for current users of the rotating logo feature.
+  validations:
+    required: false


### PR DESCRIPTION
This PR adds the same issue template we use already in the [KIC](https://github.com/kong/kubernetes-ingress-controller) for consistency.