### PR TITLE
Bump Knative to 0.18.0

### DIFF
--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -79,8 +79,8 @@ func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 
 const (
 	// TODO: later handle targeting specific versions of Knative
-	knativeCRDs = "https://github.com/knative/serving/releases/download/v0.16.0/serving-crds.yaml"
-	knativeCore = "https://github.com/knative/serving/releases/download/v0.16.0/serving-core.yaml"
+	knativeCRDs = "https://github.com/knative/serving/releases/download/v0.18.0/serving-crds.yaml"
+	knativeCore = "https://github.com/knative/serving/releases/download/v0.18.0/serving-core.yaml"
 )
 
 func deployKnative(ctx context.Context, cluster clusters.Cluster) error {

--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -79,8 +79,8 @@ func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 
 const (
 	// TODO: later handle targeting specific versions of Knative
-	knativeCRDs = "https://github.com/knative/serving/releases/download/v0.13.0/serving-crds.yaml"
-	knativeCore = "https://github.com/knative/serving/releases/download/v0.13.0/serving-core.yaml"
+	knativeCRDs = "https://github.com/knative/serving/releases/download/v0.16.0/serving-crds.yaml"
+	knativeCore = "https://github.com/knative/serving/releases/download/v0.16.0/serving-core.yaml"
 )
 
 func deployKnative(ctx context.Context, cluster clusters.Cluster) error {


### PR DESCRIPTION
0.18.0 is the earliest version that uses v1 CRDs. No apparent issues with KIC tests, which run fine with the new version.