### PR TITLE
fix: re-enable integration tests parallelization

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,8 @@ jobs:
       run: make test.integration
       env:
         KONG_ENTERPRISE_LICENSE: ${{ secrets.KONG_ENTERPRISE_LICENSE }}
+        NCPU: 2 # it was found that github actions (specifically) did not seem to perform well when spawning
+                # multiple kind clusters within a single job so this is hardcoded to 2 to ensure a limit of 2 clusters at any one point.
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2.1.0

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test.e2e:
 .PHONY: test.integration
 test.integration:
 	@GOFLAGS="-tags=integration_tests" go test \
+		-parallel $(NCPU) \
 		-timeout 45m \
 		-race \
 		-v \

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -306,11 +306,11 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 //
 // See: https://pkg.go.dev/github.com/sethvargo/go-password/password
 const (
-	secretMinLength     = 32
-	secretMinNumeric    = 8
-	secretMinAlphabetic = 8
-	secretNoUpper       = false
-	secretAllowRepeat   = false
+	secretMinLength   = 32
+	secretMinNumeric  = 8
+	secretMinSymbols  = 0
+	secretNoUpper     = false
+	secretAllowRepeat = false
 )
 
 // -----------------------------------------------------------------------------
@@ -441,7 +441,7 @@ func deployKongEnterpriseLicenseSecret(ctx context.Context, cluster clusters.Clu
 func deployEnterpriseSuperAdminPasswordSecret(ctx context.Context, cluster clusters.Cluster, namespace, password string) (string, error) {
 	var err error
 	if password == "" {
-		password, err = pwgen.Generate(secretMinLength, secretMinNumeric, secretMinAlphabetic, secretNoUpper, secretAllowRepeat)
+		password, err = pwgen.Generate(secretMinLength, secretMinNumeric, secretMinSymbols, secretNoUpper, secretAllowRepeat)
 		if err != nil {
 			return "", fmt.Errorf("no admin password was provided so an attempt was made to generate one, but it failed: %w", err)
 		}
@@ -469,7 +469,7 @@ func deployEnterpriseSuperAdminPasswordSecret(ctx context.Context, cluster clust
 // deployKongEnterpriseAdminGUISessionConf generates a session configuration for enterprise mode admin GUI and deploys that
 // as a secret to the cluster to be picked up by the enterprise enabled proxy.
 func deployKongEnterpriseAdminGUISessionConf(ctx context.Context, cluster clusters.Cluster, namespace string) error {
-	sessionSecret, err := pwgen.Generate(secretMinLength, secretMinNumeric, secretMinAlphabetic, secretNoUpper, secretAllowRepeat)
+	sessionSecret, err := pwgen.Generate(secretMinLength, secretMinNumeric, secretMinSymbols, secretNoUpper, secretAllowRepeat)
 	if err != nil {
 		return fmt.Errorf("failed to generate a secure secret for the admin gui session config: %w", err)
 	}

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestKongEnterprisePostgres(t *testing.T) {
+	t.Parallel()
+
 	t.Log("preparing kong enterprise secrets")
 	licenseJSON := os.Getenv(enterpriseLicenseEnvVar)
 	require.NotEmpty(t, licenseJSON)

--- a/test/integration/generators_test.go
+++ b/test/integration/generators_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestGenerators(t *testing.T) {
+	t.Parallel()
+
 	t.Log("creating a test environment to test generators")
 	env, err := environments.NewBuilder().Build(ctx)
 	require.NoError(t, err)

--- a/test/integration/istio_test.go
+++ b/test/integration/istio_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestIstioAddonDeployment(t *testing.T) {
+	t.Parallel()
+
 	t.Log("deploying the test cluster and environment")
 	metallbAddon := metallb.New()
 	istioAddon := istio.NewBuilder().

--- a/test/integration/kind_cluster_test.go
+++ b/test/integration/kind_cluster_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestEnvWithKindCluster(t *testing.T) {
+	t.Parallel()
+
 	t.Log("configuring the testing environment")
 	builder := environment.NewBuilder()
 
@@ -119,6 +121,8 @@ func TestEnvWithKindCluster(t *testing.T) {
 }
 
 func TestEnvWithKindClusterKongProxyOnlyMode(t *testing.T) {
+	t.Parallel()
+
 	t.Log("configuring the testing environment")
 	builder := environment.NewBuilder()
 

--- a/test/integration/kind_version_test.go
+++ b/test/integration/kind_version_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestKindClusterOlderVersion(t *testing.T) {
+	t.Parallel()
+
 	clusterVersion := semver.MustParse("1.20.7")
 	t.Logf("deploying a kind cluster with kubernetes version %s", clusterVersion)
 	builder := kind.NewBuilder().WithClusterVersion(clusterVersion)
@@ -39,6 +41,8 @@ func TestKindClusterOlderVersion(t *testing.T) {
 }
 
 func TestKindClusterNewerVersion(t *testing.T) {
+	t.Parallel()
+
 	clusterVersion := semver.MustParse("1.21.1")
 	t.Logf("deploying a kind cluster with kubernetes version %s", clusterVersion)
 	builder := kind.NewBuilder().WithClusterVersion(clusterVersion)

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestEnvironmentWithKnative(t *testing.T) {
+	t.Parallel()
+
 	t.Log("configuring the testing environment")
 	knativeAddon := knative.New()
 	builder := environments.NewBuilder().WithAddons(knativeAddon)

--- a/test/integration/metallb_test.go
+++ b/test/integration/metallb_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestEnvironmentWithMetallb(t *testing.T) {
+	t.Parallel()
+
 	t.Log("configuring the testing environment")
 	metallb := metallbaddon.New()
 	kong := kongaddon.New()

--- a/test/integration/postgres_test.go
+++ b/test/integration/postgres_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestKongWithPostgresDBMode(t *testing.T) {
+	t.Parallel()
+
 	t.Log("configuring the testing environment")
 	metallb := metallbaddon.New()
 	kong := kongaddon.NewBuilder().WithPostgreSQL().Build()


### PR DESCRIPTION
Re-enables parallel integration tests: This was disabled previously because of problems found with Github Actions when spawning multiple clusters, but this patch includes a specific limit of 2 for that environment to try and reduce that problem but still squeeze out some extra time out of the tests there.

Additionally in this PR I fixed an issue with the Kong addon which I found to be causing test flakes for the enterprise integration tests: we were configuring the number of alphabetic characters required for a generated secret in place of the numbers of symbols required. This has been fixed and the result is passwords which are still long, but don't include some characters which require special escaping or handling (which would appear to be totally fine in the use case of testing). This fixed a test flake where the enterprise enabled Kong cluster would never come up in the tests due to failure to run the migrations and the test would time out.