### PR TITLE
feat: httpbin addon

### DIFF
--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/httpbin"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
@@ -119,6 +120,8 @@ func configureAddons(cmd *cobra.Command, builder *environments.Builder, addons [
 				WithPrometheus().
 				Build()
 			builder = builder.WithAddons(istioAddon)
+		case "httpbin":
+			builder = builder.WithAddons(httpbin.New())
 		default:
 			invalid = append(invalid, addon)
 		}

--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
@@ -110,6 +111,14 @@ func configureAddons(cmd *cobra.Command, builder *environments.Builder, addons [
 			builder = builder.WithAddons(metallb.New())
 		case "kong":
 			builder = configureKongAddon(cmd, builder)
+		case "istio":
+			istioAddon := istio.NewBuilder().
+				WithGrafana().
+				WithJaeger().
+				WithKiali().
+				WithPrometheus().
+				Build()
+			builder = builder.WithAddons(istioAddon)
 		default:
 			invalid = append(invalid, addon)
 		}

--- a/pkg/clusters/addons/httpbin/addon.go
+++ b/pkg/clusters/addons/httpbin/addon.go
@@ -148,5 +148,5 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 }
 
 func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObjects []runtime.Object, ready bool, err error) {
-	return utils.IsNamespaceReady(ctx, cluster, a.namespace)
+	return utils.IsNamespaceAvailable(ctx, cluster, a.namespace)
 }

--- a/pkg/clusters/addons/httpbin/addon.go
+++ b/pkg/clusters/addons/httpbin/addon.go
@@ -1,0 +1,152 @@
+package httpbin
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/google/uuid"
+	"github.com/kong/kubernetes-testing-framework/internal/utils"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
+)
+
+// -----------------------------------------------------------------------------
+// HttpBin Addon
+// -----------------------------------------------------------------------------
+
+const (
+	// AddonName is the unique name of the HttpBin cluster.Addon
+	AddonName clusters.AddonName = "httpbin"
+
+	// Namespace is the namespace that the Addon components will be deployed
+	DefaultNamespace = "httpbin"
+
+	// Image is the container image that will be used by default.
+	Image = "kennethreitz/httpbin"
+
+	// DefaultPort is the port that will be used for the HttpBin endpoint
+	// on pods and services unless otherwise specified.
+	DefaultPort = 80
+)
+
+// Addon is a Kong Proxy addon which can be deployed on a clusters.Cluster.
+type Addon struct {
+	name               string
+	namespace          string
+	generateNamespace  bool
+	ingressAnnotations map[string]string
+	path               string
+}
+
+// New produces a new clusters.Addon for Kong but uses a very opionated set of
+// default configurations (see the defaults() function for more details).
+// If you need to customize your Kong deployment, use the kong.Builder instead.
+func New() *Addon {
+	return NewBuilder().Build()
+}
+
+// Namespace indicates the namespace where the HttpBin addon components are to be
+// deployed and managed.
+func (a *Addon) Namespace() string {
+	return a.namespace
+}
+
+// -----------------------------------------------------------------------------
+// HttpBin Addon - Public Methods
+// -----------------------------------------------------------------------------
+
+// Path provides the URL path which the addon can be reached via Ingress.
+func (a *Addon) Path() string {
+	return a.path
+}
+
+// -----------------------------------------------------------------------------
+// HttpBin Addon - Addon Implementation
+// -----------------------------------------------------------------------------
+
+func (a *Addon) Name() clusters.AddonName {
+	return AddonName
+}
+
+func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
+	// generate a namespace name if the caller optioned for that
+	if a.generateNamespace {
+		a.namespace = uuid.New().String()
+	}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: a.namespace}}
+
+	// ensure the namespace for this addon is available
+	namespace, err := cluster.Client().CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	// determine the kubernetes cluster version so we know if we need to use a legacy ingress API
+	kubernetesVersion, err := cluster.Version()
+	if err != nil {
+		return err
+	}
+
+	// generate a container, deployment, service and ingress resource for the HttpBin addon
+	a.path = fmt.Sprintf("/%s", a.name)
+	container := generators.NewContainer(a.name, Image, DefaultPort)
+	deployment, service, ingress := generators.NewIngressForContainerWithDeploymentAndService(
+		kubernetesVersion,
+		container,
+		corev1.ServiceTypeClusterIP,
+		a.ingressAnnotations,
+		a.path,
+	)
+
+	// deploy the httpbin deployment
+	_, err = cluster.Client().AppsV1().Deployments(a.namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	// expose httpbin inside the cluster via service
+	_, err = cluster.Client().CoreV1().Services(a.namespace).Create(ctx, service, metav1.CreateOptions{})
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	// expose httpbin outside the cluster via ingress
+	if err := clusters.DeployIngress(ctx, cluster, a.namespace, ingress); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context completed before addon could be deleted: %w", ctx.Err())
+		default:
+			if err := cluster.Client().CoreV1().Namespaces().Delete(ctx, a.namespace, metav1.DeleteOptions{}); err != nil {
+				if errors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+		}
+	}
+}
+
+func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObjects []runtime.Object, ready bool, err error) {
+	return utils.IsNamespaceReady(ctx, cluster, a.namespace)
+}

--- a/pkg/clusters/addons/httpbin/addon.go
+++ b/pkg/clusters/addons/httpbin/addon.go
@@ -23,7 +23,7 @@ const (
 	// AddonName is the unique name of the HttpBin cluster.Addon
 	AddonName clusters.AddonName = "httpbin"
 
-	// Namespace is the namespace that the Addon components will be deployed
+	// DefaultNamespace is the namespace that the Addon components will be deployed
 	DefaultNamespace = "httpbin"
 
 	// Image is the container image that will be used by default.
@@ -81,7 +81,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: a.namespace}}
 
 	// ensure the namespace for this addon is available
-	namespace, err := cluster.Client().CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+	_, err := cluster.Client().CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err

--- a/pkg/clusters/addons/httpbin/builder.go
+++ b/pkg/clusters/addons/httpbin/builder.go
@@ -1,0 +1,77 @@
+package httpbin
+
+// -----------------------------------------------------------------------------
+// Kong Addon - Builder
+// -----------------------------------------------------------------------------
+
+// Builder is a configuration tool to generate HttpBin cluster addons.
+type Builder struct {
+	name               string
+	namespace          string
+	generateNamespace  bool
+	ingressAnnotations map[string]string
+}
+
+// NewBuilder provides a new Builder object for configuring HttpBin cluster addons.
+func NewBuilder() *Builder {
+	return &Builder{
+		name:               string(AddonName),
+		namespace:          DefaultNamespace,
+		ingressAnnotations: make(map[string]string),
+	}
+}
+
+// WithName indicates the name of the Addon which is useful if the caller intends
+// to deploy multiple copies of the addon into a single namespace.
+func (b *Builder) WithName(name string) *Builder {
+	b.name = name
+	return b
+}
+
+// WithNamespace allows the namespace where the addon should be deployed to be
+// overridden from the default.
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	b.namespace = namespace
+	return b
+}
+
+// WithGeneratedNamespace indicates that a uniquely named namespace should be
+// used. Helpful when deploying multiple copies of HttpBin to the cluster.
+func (b *Builder) WithGeneratedNamespace() *Builder {
+	b.generateNamespace = true
+	return b
+}
+
+// WithIngressAnnotations allows injecting the annotations that will be placed
+// on the HttpBin Ingress resource for things like deciding the ingress.class.
+// This will override values for new keys provided, but will combine with any
+// other previously existing keys.
+func (b *Builder) WithIngressAnnotations(anns map[string]string) *Builder {
+	for k, v := range anns {
+		b.ingressAnnotations[k] = v
+	}
+	return b
+}
+
+// Build generates a new kong cluster.Addon which can be loaded and deployed
+// into a test Environment's cluster.Cluster.
+func (b *Builder) Build() *Addon {
+	// if no ingress.class annotations are provided we'll assume Kong should
+	// be the ingress class.
+	if _, ok := b.ingressAnnotations["networking.knative.dev/ingress.class"]; !ok {
+		b.ingressAnnotations["networking.knative.dev/ingress.class"] = "kong"
+	}
+	if _, ok := b.ingressAnnotations["kubernetes.io/ingress.class"]; !ok {
+		b.ingressAnnotations["kubernetes.io/ingress.class"] = "kong"
+	}
+	if _, ok := b.ingressAnnotations["konghq.com/strip-path"]; !ok {
+		b.ingressAnnotations["konghq.com/strip-path"] = "true"
+	}
+
+	return &Addon{
+		name:               b.name,
+		namespace:          b.namespace,
+		generateNamespace:  b.generateNamespace,
+		ingressAnnotations: b.ingressAnnotations,
+	}
+}

--- a/pkg/clusters/addons/istio/addon.go
+++ b/pkg/clusters/addons/istio/addon.go
@@ -202,7 +202,7 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 }
 
 func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObjects []runtime.Object, ready bool, err error) {
-	return utils.IsNamespaceReady(ctx, cluster, Namespace)
+	return utils.IsNamespaceAvailable(ctx, cluster, Namespace)
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -61,7 +61,7 @@ func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	var waitingForObjects []runtime.Object
 	for i := 0; i < len(deploymentList.Items); i++ {
 		deployment := &(deploymentList.Items[i])
-		if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
+		if deployment.Status.AvailableReplicas != *deployment.Spec.Replicas {
 			waitingForObjects = append(waitingForObjects, deployment)
 		}
 	}

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -293,7 +293,7 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 }
 
 func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObjects []runtime.Object, ready bool, err error) {
-	return utils.IsNamespaceReady(ctx, cluster, a.namespace)
+	return utils.IsNamespaceAvailable(ctx, cluster, a.namespace)
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -94,7 +94,7 @@ func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 		return nil, false, err
 	}
 
-	if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
+	if deployment.Status.AvailableReplicas != *deployment.Spec.Replicas {
 		return []runtime.Object{deployment}, false, nil
 	}
 

--- a/pkg/environments/implementation.go
+++ b/pkg/environments/implementation.go
@@ -52,7 +52,7 @@ func (env *environment) Ready(ctx context.Context) (waitForObjects []runtime.Obj
 
 	for i := 0; i < len(deployments.Items); i++ {
 		deployment := &(deployments.Items[i])
-		if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
+		if deployment.Status.AvailableReplicas != *deployment.Spec.Replicas {
 			waitForObjects = append(waitForObjects, deployment)
 		}
 	}

--- a/pkg/utils/networking/http.go
+++ b/pkg/utils/networking/http.go
@@ -1,0 +1,39 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// WaitForHTTP will make an HTTP GET request to the given URL until either
+// the responses return the expected status code or the context completes (and
+// then it will throw an error). The main purpose of this function is basically
+// just to wait for an HTTP server that has been deployed to be ready without
+// needing to bother with checking pod status, health e.t.c.
+func WaitForHTTP(ctx context.Context, getURL string, statusCode int) chan error {
+	errs := make(chan error)
+	go func() {
+		httpc := http.Client{Timeout: time.Second * 10}
+		for {
+			select {
+			case <-ctx.Done():
+				errs <- fmt.Errorf("context completed before path %s returned %d: %w", getURL, statusCode, ctx.Err())
+				close(errs)
+			default:
+				resp, err := httpc.Get(getURL)
+				if err != nil {
+					continue
+				}
+				resp.Body.Close()
+				if resp.StatusCode == statusCode {
+					errs <- nil
+					close(errs)
+					return
+				}
+			}
+		}
+	}()
+	return errs
+}

--- a/pkg/utils/networking/http.go
+++ b/pkg/utils/networking/http.go
@@ -15,7 +15,7 @@ import (
 func WaitForHTTP(ctx context.Context, getURL string, statusCode int) chan error {
 	errs := make(chan error)
 	go func() {
-		httpc := http.Client{Timeout: time.Second * 10}
+		httpc := http.Client{Timeout: time.Second * 10} //nolint:gomnd
 		for {
 			select {
 			case <-ctx.Done():

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -127,7 +127,7 @@ func TestGKECluster(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
+		return deployment.Status.AvailableReplicas == *deployment.Spec.Replicas
 	}, time.Minute*1, time.Second*1)
 
 	t.Logf("exposing deployment %s via service", deployment.Name)

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -15,14 +15,11 @@ import (
 
 	"github.com/sethvargo/go-password/password"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/httpbin"
 	kongaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	metallbaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
-	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
 func TestKongEnterprisePostgres(t *testing.T) {
@@ -114,31 +111,16 @@ func TestKongEnterprisePostgres(t *testing.T) {
 		return resp.StatusCode == http.StatusCreated
 	}, time.Minute, time.Second)
 
-	t.Log("deploying an HTTP service to test the ingress controller and proxy")
-	container := generators.NewContainer("httpbin", httpBinImage, 80)
-	deployment := generators.NewDeploymentForContainer(container)
-	deployment, err = env.Cluster().Client().AppsV1().Deployments(corev1.NamespaceDefault).Create(ctx, deployment, metav1.CreateOptions{})
-	require.NoError(t, err)
+	t.Log("deploying httpbin and waiting for readiness")
+	httpbinAddon := httpbin.New()
+	require.NoError(t, env.Cluster().DeployAddon(ctx, httpbinAddon))
+	require.NoError(t, <-env.WaitForReady(ctx))
 
-	t.Logf("exposing deployment %s via service", deployment.Name)
-	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
-	_, err = env.Cluster().Client().CoreV1().Services(corev1.NamespaceDefault).Create(ctx, service, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, ingressClass)
-	kubernetesVersion, err := env.Cluster().Version()
-	require.NoError(t, err)
-	ingress := generators.NewIngressForServiceWithClusterVersion(kubernetesVersion, "/httpbin", map[string]string{
-		ingressClassKey:         ingressClass,
-		"konghq.com/strip-path": "true",
-	}, service)
-	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), corev1.NamespaceDefault, ingress))
-
-	t.Log("waiting for routes from Ingress to be operational")
-	httpc = http.Client{Timeout: time.Second * 10}
+	t.Log("accessing httpbin via ingress to validate that the kong proxy is functioning")
 	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/httpbin", proxyURL.String()))
+		resp, err := httpc.Get(fmt.Sprintf("%s/%s", proxyURL, httpbinAddon.Path()))
 		if err != nil {
+			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
 			return false
 		}
 		defer resp.Body.Close()

--- a/test/integration/generators_test.go
+++ b/test/integration/generators_test.go
@@ -65,7 +65,7 @@ func TestGenerators(t *testing.T) {
 			require.Eventually(t, func() bool {
 				deployment, err := env.Cluster().Client().AppsV1().Deployments(namespace.Name).Get(ctx, "httpbin", metav1.GetOptions{})
 				require.NoError(t, err)
-				return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
+				return deployment.Status.AvailableReplicas == *deployment.Spec.Replicas
 			}, time.Minute*3, time.Second)
 		}
 	}

--- a/test/integration/generators_test.go
+++ b/test/integration/generators_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -65,7 +66,7 @@ func TestGenerators(t *testing.T) {
 				deployment, err := env.Cluster().Client().AppsV1().Deployments(namespace.Name).Get(ctx, "httpbin", metav1.GetOptions{})
 				require.NoError(t, err)
 				return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas
-			}, httpbinWait, waitTick)
+			}, time.Minute*3, time.Second)
 		}
 	}
 

--- a/test/integration/istio_test.go
+++ b/test/integration/istio_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/httpbin"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
@@ -47,7 +48,7 @@ func TestIstioAddonDeployment(t *testing.T) {
 	require.NoError(t, istioAddon.EnableMeshForNamespace(ctx, env.Cluster(), "with-istio"))
 
 	t.Log("adding a test deployment into each namespace")
-	container := generators.NewContainer("httpbin", httpBinImage, 80)
+	container := generators.NewContainer("httpbin", httpbin.Image, 80)
 	deployment = generators.NewDeploymentForContainer(container)
 	for _, namespace := range []string{"without-istio", "with-istio"} {
 		deployment.Namespace = namespace

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"context"
-	"time"
 )
 
 // -----------------------------------------------------------------------------
@@ -13,14 +12,6 @@ import (
 
 const (
 	enterpriseLicenseEnvVar = "KONG_ENTERPRISE_LICENSE"
-
-	httpBinImage = "kennethreitz/httpbin"
-	httpbinWait  = time.Minute * 2
-
-	ingressClassKey = "kubernetes.io/ingress.class"
-	ingressClass    = "kong"
-
-	waitTick = time.Second
 )
 
 var (


### PR DESCRIPTION
This PR adds a new `httpbin` addon as that was becoming a common workflow across all testing, as well as making some other general improvements:

- feat: add new generator for ingress from container spec
- feat: add httpbin cluster addon
- chore: add httpbin addon into integration tests
- feat: enable istio addon in ktf cli
- feat: enable httpbion addon in ktf cli
- chore: use availability instead of readiness
- feat: http wait function in networking utils

Resolves https://github.com/Kong/kubernetes-testing-framework/issues/126