### PR TITLE
feat: add enterprise kong license utils

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: run integration tests
       run: make test.integration
       env:
-        KONG_ENTERPRISE_LICENSE: ${{ secrets.KONG_ENTERPRISE_LICENSE }}
+        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
 
     - name: run e2e tests
       run: make test.e2e
@@ -59,7 +59,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
         GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-        KONG_ENTERPRISE_LICENSE: ${{ secrets.KONG_ENTERPRISE_LICENSE }}
+        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
 
     # --------------------------------------------------------------------------
     # Release Tagging

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: run integration tests
       run: make test.integration
       env:
-        KONG_ENTERPRISE_LICENSE: ${{ secrets.KONG_ENTERPRISE_LICENSE }}
+        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
         NCPU: 2 # it was found that github actions (specifically) did not seem to perform well when spawning
                 # multiple kind clusters within a single job so this is hardcoded to 2 to ensure a limit of 2 clusters at any one point.
 

--- a/pkg/clusters/addons/kong/enterprise.go
+++ b/pkg/clusters/addons/kong/enterprise.go
@@ -1,0 +1,133 @@
+package kong
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// -----------------------------------------------------------------------------
+// Kong License - Consts & Vars
+// -----------------------------------------------------------------------------
+
+// LicenseDataEnvVar is the environment variable where the Kong enterprise
+// license will be stored if available for tests.
+const LicenseDataEnvVar = "KONG_LICENSE_DATA"
+
+// partialRFC3339Regex is a regex to match on timestamps that are only the date
+// portion of an RFC3339 timestamp, this is commonly used in Kong license timestamps.
+var partialRFC3339Regex = regexp.MustCompile("^[0-9]+-[0-9]+-[0-9]+$")
+
+// -----------------------------------------------------------------------------
+// Kong License - Public Types
+// -----------------------------------------------------------------------------
+
+type LicensePayload struct {
+	AdminSeats          string `json:"admin_seats"`
+	Customer            string `json:"customer"`
+	DataPlanes          string `json:"dataplanes"`
+	CreationDate        string `json:"license_creation_date"`
+	ExpirationDate      string `json:"license_expiration_date"`
+	Key                 string `json:"license_key"`
+	ProductSubscription string `json:"product_subscription"`
+	SupportPlan         string `json:"support_plan"`
+}
+
+type LicenseData struct {
+	Payload   LicensePayload `json:"payload"`
+	Signature string         `json:"signature"`
+	Version   string         `json:"version"`
+}
+
+type License struct {
+	Data LicenseData `json:"license"`
+}
+
+// -----------------------------------------------------------------------------
+// Kong License - Helper Functions
+// -----------------------------------------------------------------------------
+
+// GetLicenseJSONFromEnv retrieves the license data from the environment and
+// validates it, returning the resulting JSON string.
+func GetLicenseJSONFromEnv() (string, error) {
+	licenseObj, err := GetLicenseFromEnv()
+	if err != nil {
+		return "", err
+	}
+
+	b, err := json.Marshal(licenseObj)
+	return string(b), err
+}
+
+// GetLicenseFromEnv retrieves the license data from the environment and
+// validates it, returning the resulting *License object.
+func GetLicenseFromEnv() (*License, error) {
+	licenseJSON := os.Getenv(LicenseDataEnvVar)
+	if licenseJSON == "" {
+		return nil, fmt.Errorf("no license could be found because %s was not set", LicenseDataEnvVar)
+	}
+
+	// validate overall structure
+	licenseObj := &License{}
+	if err := json.Unmarshal([]byte(licenseJSON), licenseObj); err != nil {
+		return nil, fmt.Errorf("invalid license JSON: %w", err)
+	}
+
+	// validate license expiration date
+	expirationDateStr := licenseObj.Data.Payload.ExpirationDate
+	if partialRFC3339Regex.MatchString(expirationDateStr) {
+		// allow for shorthand dates which don't match the full RFC3339 spec,
+		// but assume the very beginning of the day.
+		expirationDateStr = fmt.Sprintf("%sT00:00:01Z", expirationDateStr)
+	}
+	t, err := time.Parse(time.RFC3339, expirationDateStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid license date (%s): %w", expirationDateStr, err)
+	}
+
+	// validate expiration
+	if time.Now().UTC().After(t) {
+		return nil, fmt.Errorf("the provided %s is expired", LicenseDataEnvVar)
+	}
+
+	return licenseObj, nil
+}
+
+// GetLicenseSecretYAMLFromEnv retrieves the license data from the environment and
+// validates it, returning a Kubernetes Secret manifest containing the license.
+func GetLicenseSecretYAMLFromEnv() (string, error) {
+	licenseSecret, err := GetLicenseSecretFromEnv()
+	if err != nil {
+		return "", err
+	}
+
+	licenseSecretYAML, err := yaml.Marshal(licenseSecret)
+	return string(licenseSecretYAML), err
+}
+
+// GetLicenseSecretFromEnv retrieves the license data from the environment and
+// validates it, returning a Kubernetes Secret object containing the license.
+func GetLicenseSecretFromEnv() (*corev1.Secret, error) {
+	// get a validated copy of the license JSON
+	licenseJSON, err := GetLicenseJSONFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("could not generate license secret: %w", err)
+	}
+
+	// generate a secret
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kong-enterprise-license",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"license": []byte(licenseJSON),
+		},
+	}, nil
+}

--- a/pkg/clusters/addons/kong/enterprise_test.go
+++ b/pkg/clusters/addons/kong/enterprise_test.go
@@ -1,0 +1,58 @@
+package kong
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLicenseJSON(t *testing.T) {
+	t.Logf("saving the original value of %s to restore when tests complete", LicenseDataEnvVar)
+	originalValue := os.Getenv(LicenseDataEnvVar)
+	defer func() {
+		assert.NoError(t, os.Setenv(LicenseDataEnvVar, originalValue))
+	}()
+
+	t.Log("gathering various dates to test license validation and expiry")
+	now := time.Now().UTC()
+	yesterday := now.Add(time.Hour * -24)
+	tomorrow := now.Add(time.Hour * 24)
+
+	t.Log("testing license validation for a valid license")
+	tomorrowsDateStr := tomorrow.Format(time.RFC3339)
+	validLicense := &License{Data: LicenseData{Payload: LicensePayload{ExpirationDate: tomorrowsDateStr}}}
+	validLicenseJSON, err := json.Marshal(validLicense)
+	assert.NoError(t, err)
+	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(validLicenseJSON)))
+	parsedLicenseJSON, err := GetLicenseJSONFromEnv()
+	assert.NoError(t, err)
+	assert.Equal(t, string(validLicenseJSON), parsedLicenseJSON)
+
+	t.Log("testing out of date license validation")
+	yesterdaysDateStr := yesterday.Format(time.RFC3339)
+	invalidLicense := &License{Data: LicenseData{Payload: LicensePayload{ExpirationDate: yesterdaysDateStr}}}
+	invalidLicenseJSON, err := json.Marshal(invalidLicense)
+	assert.NoError(t, err)
+	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(invalidLicenseJSON[:])))
+	_, err = GetLicenseJSONFromEnv()
+	assert.Error(t, err)
+
+	t.Log("testing out of date license validation with a raw string")
+	invalidLicense = &License{Data: LicenseData{Payload: LicensePayload{ExpirationDate: "2021-10-20"}}}
+	invalidLicenseJSON, err = json.Marshal(invalidLicense)
+	assert.NoError(t, err)
+	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(invalidLicenseJSON[:])))
+	_, err = GetLicenseJSONFromEnv()
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("the provided %s is expired", LicenseDataEnvVar), err.Error())
+
+	t.Log("testing generation of kubernetes secret license")
+	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(validLicenseJSON)))
+	licenseSecret, err := GetLicenseSecretFromEnv()
+	assert.NoError(t, err)
+	assert.Equal(t, validLicenseJSON, licenseSecret.Data["license"])
+}

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/httpbin"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	kongaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
 	metallbaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
 	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
@@ -27,8 +27,8 @@ func TestKongEnterprisePostgres(t *testing.T) {
 	t.Parallel()
 
 	t.Log("preparing kong enterprise secrets")
-	licenseJSON := os.Getenv(enterpriseLicenseEnvVar)
-	require.NotEmpty(t, licenseJSON)
+	licenseJSON, err := kong.GetLicenseJSONFromEnv()
+	require.NoError(t, err)
 	adminPassword, err := password.Generate(10, 5, 0, false, false)
 	require.NoError(t, err)
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -11,10 +11,6 @@ import (
 // Testing Vars & Consts
 // -----------------------------------------------------------------------------
 
-const (
-	enterpriseLicenseEnvVar = "KONG_ENTERPRISE_LICENSE"
-)
-
 var (
 	// ctx is a common context that can be used between tests
 	ctx = context.Background()


### PR DESCRIPTION
This patch adds some utilities for retrieving and validating the Kong Enterprise License from the environment, and plugs them into the existing test suite.

This is in support of providing a consistent means between KTF and KIC for which environment variable contains the license data, and otherwise to just provide a consistent way to get it.

The validation added also allows tests to fail faster if the license data is somehow invalid, or if an otherwise valid license is out of date.