### PR TITLE
feat: cert-manager addon

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,4 +36,4 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2.5.2
       with:
-        version: v1.40.1
+        version: v1.42.1

--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -8,6 +8,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/certmanager"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/httpbin"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/istio"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
@@ -122,6 +123,8 @@ func configureAddons(cmd *cobra.Command, builder *environments.Builder, addons [
 			builder = builder.WithAddons(istioAddon)
 		case "httpbin":
 			builder = builder.WithAddons(httpbin.New())
+		case "cert-manager":
+			builder = builder.WithAddons(certmanager.New())
 		default:
 			invalid = append(invalid, addon)
 		}

--- a/pkg/clusters/addons/certmanager/addon.go
+++ b/pkg/clusters/addons/certmanager/addon.go
@@ -1,0 +1,183 @@
+package certmanager
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/blang/semver/v4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/github"
+)
+
+// -----------------------------------------------------------------------------
+// CertManager Addon - Builder
+// -----------------------------------------------------------------------------
+
+type Builder struct {
+	version *semver.Version
+}
+
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+func (b *Builder) WithVersion(version semver.Version) *Builder {
+	b.version = &version
+	return b
+}
+
+func (b *Builder) Build() *Addon {
+	return &Addon{
+		version: b.version,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// CertManager Addon
+// -----------------------------------------------------------------------------
+
+const (
+	// AddonName indicates the unique name of this addon.
+	AddonName clusters.AddonName = "cert-manager"
+
+	// DefaultNamespace indicates the default namespace this addon will be deployed to.
+	DefaultNamespace = "cert-manager"
+)
+
+type Addon struct {
+	version *semver.Version
+}
+
+func New() clusters.Addon {
+	return &Addon{}
+}
+
+// -----------------------------------------------------------------------------
+// CertManager Addon - Addon Implementation
+// -----------------------------------------------------------------------------
+
+func (a *Addon) Name() clusters.AddonName {
+	return AddonName
+}
+
+func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
+	var err error
+	if a.version == nil {
+		a.version, err = github.FindLatestReleaseForRepo("jetstack", "cert-manager")
+		if err != nil {
+			return err
+		}
+	}
+
+	kubeconfig, err := clusters.TempKubeconfig(cluster)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(kubeconfig.Name())
+
+	deployArgs := []string{
+		"--kubeconfig", kubeconfig.Name(),
+		"apply", "-f", fmt.Sprintf(manifestFormatter, a.version),
+	}
+
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("kubectl", deployArgs...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", stderr.String(), err)
+	}
+
+	// we need to wait for deployment readiness before we try to deploy a
+	// default issuer for the cluster.
+	deploymentsReady := false
+	for !deploymentsReady {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context completed before deployment could complete: %w", ctx.Err())
+		default:
+			_, deploymentsReady, err = a.Ready(ctx, cluster)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return a.deployDefaultIssuer(ctx, cluster)
+}
+
+func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
+	kubeconfig, err := clusters.TempKubeconfig(cluster)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(kubeconfig.Name())
+
+	deployArgs := []string{
+		"--kubeconfig", kubeconfig.Name(),
+		"delete", "-f", fmt.Sprintf(manifestFormatter, a.version),
+	}
+
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("kubectl", deployArgs...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", stderr.String(), err)
+	}
+
+	return a.cleanupDefaultIssuer(ctx, cluster)
+}
+
+func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.Object, bool, error) {
+	for _, deploymentName := range []string{"cert-manager", "cert-manager-cainjector", "cert-manager-webhook"} {
+		deployment, err := cluster.Client().AppsV1().Deployments(DefaultNamespace).
+			Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+
+		if deployment.Status.AvailableReplicas != *deployment.Spec.Replicas {
+			return []runtime.Object{deployment}, false, nil
+		}
+	}
+
+	return nil, true, nil
+}
+
+// -----------------------------------------------------------------------------
+// CertManager Addon - Private
+// -----------------------------------------------------------------------------
+
+const (
+	manifestFormatter        = "https://github.com/jetstack/cert-manager/releases/download/v%s/cert-manager.yaml"
+	defaultIssuerWaitSeconds = 60
+	defaultIssuer            = `---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+`
+)
+
+func (a *Addon) deployDefaultIssuer(ctx context.Context, cluster clusters.Cluster) error {
+	if err := clusters.ApplyYAML(ctx, cluster, defaultIssuer); err != nil {
+		return err
+	}
+	return clusters.WaitForCondition(ctx, cluster, DefaultNamespace, "clusterissuers.cert-manager.io", "selfsigned", "Ready", defaultIssuerWaitSeconds)
+}
+
+func (a *Addon) cleanupDefaultIssuer(ctx context.Context, cluster clusters.Cluster) error {
+	return clusters.DeleteYAML(ctx, cluster, defaultIssuer)
+}

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -92,6 +92,8 @@ func (a *Addon) Namespace() string {
 // Kong Addon - Proxy Endpoint Methods
 // -----------------------------------------------------------------------------
 
+const defaultHTTPPort = 80
+
 // ProxyURL provides a routable *url.URL for accessing the Kong proxy.
 func (a *Addon) ProxyURL(ctx context.Context, cluster clusters.Cluster) (*url.URL, error) {
 	waitForObjects, ready, err := a.Ready(ctx, cluster)
@@ -103,7 +105,7 @@ func (a *Addon) ProxyURL(ctx context.Context, cluster clusters.Cluster) (*url.UR
 		return nil, fmt.Errorf("the addon is not ready on cluster %s: non-empty unresolved objects list: %+v", cluster.Name(), waitForObjects)
 	}
 
-	return urlForService(ctx, cluster, types.NamespacedName{Namespace: a.namespace, Name: DefaultProxyServiceName}, 80)
+	return urlForService(ctx, cluster, types.NamespacedName{Namespace: a.namespace, Name: DefaultProxyServiceName}, defaultHTTPPort)
 }
 
 // ProxyAdminURL provides a routable *url.URL for accessing the Kong Admin API.

--- a/pkg/utils/github/release.go
+++ b/pkg/utils/github/release.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/blang/semver/v4"
+)
+
+const releaseURLFormatter = "https://api.github.com/repos/%s/%s/releases/latest"
+
+// FindLatestReleaseForRepo returns the latest release tag for a Github
+// repository given an Organization and Repository name.
+//
+// NOTE: latest release in this context does not necessarily mean the newest
+//       version: if a repo releases a patch for an older release for instance
+//       the the returned version could be that instead.
+func FindLatestReleaseForRepo(org, repo string) (*semver.Version, error) {
+	releaseURL := fmt.Sprintf(releaseURLFormatter, org, repo)
+	resp, err := http.Get(releaseURL) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("couldn't determine latest %s/%s release: %w", org, repo, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	type latestReleaseData struct {
+		TagName string `json:"tag_name"`
+	}
+
+	data := latestReleaseData{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("bad data from api when fetching latest %s/%s release tag: %w", org, repo, err)
+	}
+
+	latestVersion, err := semver.Parse(strings.TrimPrefix(data.TagName, "v"))
+	if err != nil {
+		return nil, fmt.Errorf("bad release tag returned from api when fetching latest %s/%s release tag: %w", org, repo, err)
+	}
+
+	return &latestVersion, err
+}

--- a/test/integration/certmanager_test.go
+++ b/test/integration/certmanager_test.go
@@ -1,0 +1,74 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/certmanager"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+)
+
+func TestCertManagerAddon(t *testing.T) {
+	t.Parallel()
+
+	t.Log("building the testing environment and Kubernetes cluster")
+	env, err := environments.NewBuilder().WithAddons(certmanager.New()).Build(ctx)
+	require.NoError(t, err)
+
+	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())
+	defer func() {
+		t.Logf("cleaning up environment %s and cluster %s", env.Name(), env.Cluster().Name())
+		assert.NoError(t, env.Cleanup(ctx))
+	}()
+
+	t.Log("waiting for cluster and addons to be ready")
+	require.NoError(t, <-env.WaitForReady(ctx))
+
+	t.Log("deploying a cert-manager certificate to the cluster")
+	require.NoError(t, clusters.ApplyYAML(ctx, env.Cluster(), `---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: certificate-for-integration-tests
+  namespace: default
+spec:
+  secretName: certificate-for-integration-tests
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+      - kong
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 4096
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - konghq.com
+    - docs.konghq.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned
+`))
+
+	t.Log("verifying that the certificate gets provisioned by cert-manager")
+	require.NoError(t, clusters.WaitForCondition(ctx, env.Cluster(), corev1.NamespaceDefault, "certificates.cert-manager.io", "certificate-for-integration-tests", "Ready", 30))
+
+	t.Log("ensuring that the certificate secret was created properly")
+	require.Eventually(t, func() bool {
+		_, err := env.Cluster().Client().CoreV1().Secrets(corev1.NamespaceDefault).Get(ctx, "certificate-for-integration-tests", metav1.GetOptions{})
+		return err == nil
+	}, time.Minute, time.Second)
+}

--- a/test/integration/istio_test.go
+++ b/test/integration/istio_test.go
@@ -1,7 +1,6 @@
 //go:build integration_tests
 // +build integration_tests
 
-
 package integration
 
 import (


### PR DESCRIPTION
This patch adds a [CertManager](https://cert-manager.io) addon as well as a few new utility functions that help support it.

This is helpful for KIC when we would want to test TLS, and also helpful for https://github.com/Kong/kubernetes-testing-framework/issues/147 in case we want to use [Harbor](https://github.com/goharbor) (it requires `cert-manager`).