### PR TITLE
Add support for getting node addresses and loading images

### DIFF
--- a/pkg/clusters/cluster.go
+++ b/pkg/clusters/cluster.go
@@ -46,4 +46,7 @@ type Cluster interface {
 
 	// DeleteAddon removes an existing cluster Addon.
 	DeleteAddon(ctx context.Context, addon Addon) error
+
+	// GetNodeAddresses returns a list of cluster worker node addresses
+	GetNodeAddresses(ctx context.Context) ([]string, error)
 }


### PR DESCRIPTION
Two separate features:

1. Add a new `GetNodeAddresses()` cluster function which returns a cluster's worker node addresses. Note that GKE does not allow access through these by default (at least not for NodePorts--unsure if they allow anything else by default).
2. Add a new loadimage plugin. It loads images into KIND clusters.