### PR TITLE
feat: add Cluster node addresses getter method

### DIFF
--- a/pkg/clusters/cluster.go
+++ b/pkg/clusters/cluster.go
@@ -46,4 +46,7 @@ type Cluster interface {
 
 	// DeleteAddon removes an existing cluster Addon.
 	DeleteAddon(ctx context.Context, addon Addon) error
+
+	// GetNodeAddresses returns a list of cluster worker node addresses
+	GetNodeAddresses(ctx context.Context) ([]string, error)
 }


### PR DESCRIPTION
Split from https://github.com/Kong/kubernetes-testing-framework/pull/149

Add a new GetNodeAddresses() cluster function which returns a cluster's worker node addresses. Note that GKE does not allow access through these by default (at least not for NodePorts--unsure if they allow anything else by default). It does [still work as expected](https://github.com/Kong/kubernetes-testing-framework/pull/149#discussion_r748467326), I'm just not immediately sure how you'd use it. Node addresses are a property available on all clusters, however, regardless of their surrounding network and firewall rules, so this should go into the Cluster interface.