### PR TITLE
feat: add load image addon

### DIFF
--- a/pkg/clusters/addons/loadimage/addon.go
+++ b/pkg/clusters/addons/loadimage/addon.go
@@ -37,11 +37,6 @@ func (a *Addon) Name() clusters.AddonName {
 }
 
 func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
-	if a.image == "" {
-		a.loaded = true
-		return nil
-	}
-
 	switch ctype := cluster.Type(); ctype {
 	case kind.KindClusterType:
 		if err := a.loadIntoKind(cluster); err != nil {

--- a/pkg/clusters/addons/loadimage/addon.go
+++ b/pkg/clusters/addons/loadimage/addon.go
@@ -55,8 +55,16 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 }
 
 func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
-	// per https://github.com/kubernetes-sigs/kind/issues/658 this is basically impossible
-	return fmt.Errorf("cannot remove loaded images from a cluster")
+	switch ctype := cluster.Type(); ctype {
+	case kind.KindClusterType:
+		// per https://github.com/kubernetes-sigs/kind/issues/658 this is basically impossible
+		// we lie here, because we want to mask this error. not deleting an image from KIND is benign:
+		// you either don't use it after (in which case you shouldn't care that it's still present) or
+		// load another image with the same name (in which case the name will point to the new image)
+		return nil
+	default:
+		return fmt.Errorf("loadimage addon is not supported by cluster type '%v'", cluster.Type())
+	}
 }
 
 func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.Object, bool, error) {

--- a/pkg/clusters/addons/loadimage/addon.go
+++ b/pkg/clusters/addons/loadimage/addon.go
@@ -1,0 +1,101 @@
+package loadimage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
+)
+
+// -----------------------------------------------------------------------------
+// CertManager Addon - Builder
+// -----------------------------------------------------------------------------
+
+type Builder struct {
+	image string
+}
+
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+func (b *Builder) WithImage(image string) *Builder {
+	b.image = image
+	return b
+}
+
+func (b *Builder) Build() *Addon {
+	return &Addon{
+		image:  b.image,
+		loaded: false,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// CertManager Addon
+// -----------------------------------------------------------------------------
+
+const (
+	// AddonName indicates the unique name of this addon.
+	AddonName clusters.AddonName = "loadimage"
+)
+
+type Addon struct {
+	image  string
+	loaded bool
+}
+
+func New() clusters.Addon {
+	return &Addon{}
+}
+
+// -----------------------------------------------------------------------------
+// CertManager Addon - Addon Implementation
+// -----------------------------------------------------------------------------
+
+func (a *Addon) Name() clusters.AddonName {
+	return AddonName
+}
+
+func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
+	if a.image == "" {
+		a.loaded = true
+		return nil
+	}
+	if cluster.Type() != kind.KindClusterType {
+		return fmt.Errorf("addon %v is not available on cluster types other than %v", a.Name(), kind.KindClusterType)
+	}
+	deployArgs := []string{
+		"load", "docker-image",
+		a.image,
+		"--name", cluster.Name(),
+	}
+
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("kind", deployArgs...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", stderr.String(), err)
+	}
+	a.loaded = true
+
+	return nil
+}
+
+func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
+	// per https://github.com/kubernetes-sigs/kind/issues/658 this is basically impossible
+	return fmt.Errorf("cannot remove loaded images from a cluster")
+}
+
+func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.Object, bool, error) {
+	// no way to verify this, we rely on Deploy's cmd.Run() not failing
+	return nil, a.loaded, nil
+}

--- a/pkg/clusters/addons/loadimage/builder.go
+++ b/pkg/clusters/addons/loadimage/builder.go
@@ -1,5 +1,9 @@
 package loadimage
 
+import (
+	"errors"
+)
+
 // -----------------------------------------------------------------------------
 // CertManager Addon - Builder
 // -----------------------------------------------------------------------------
@@ -12,9 +16,12 @@ func NewBuilder() *Builder {
 	return &Builder{}
 }
 
-func (b *Builder) WithImage(image string) *Builder {
+func (b *Builder) WithImage(image string) (*Builder, error) {
+	if len(image) == 0 {
+		return nil, errors.New("no image provided")
+	}
 	b.image = image
-	return b
+	return b, nil
 }
 
 func (b *Builder) Build() *Addon {

--- a/pkg/clusters/addons/loadimage/builder.go
+++ b/pkg/clusters/addons/loadimage/builder.go
@@ -1,0 +1,25 @@
+package loadimage
+
+// -----------------------------------------------------------------------------
+// CertManager Addon - Builder
+// -----------------------------------------------------------------------------
+
+type Builder struct {
+	image string
+}
+
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+func (b *Builder) WithImage(image string) *Builder {
+	b.image = image
+	return b
+}
+
+func (b *Builder) Build() *Addon {
+	return &Addon{
+		image:  b.image,
+		loaded: false,
+	}
+}

--- a/pkg/clusters/addons/loadimage/cluster_implementations.go
+++ b/pkg/clusters/addons/loadimage/cluster_implementations.go
@@ -1,0 +1,29 @@
+package loadimage
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+func (a *Addon) loadIntoKind(cluster clusters.Cluster) error {
+	deployArgs := []string{
+		"load", "docker-image",
+		a.image,
+		"--name", cluster.Name(),
+	}
+
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("kind", deployArgs...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", stderr.String(), err)
+	}
+	a.loaded = true
+	return nil
+}


### PR DESCRIPTION
This is one of two proposals to add image loading to KTF, broken out of #149. It is mutually exclusive with https://github.com/Kong/kubernetes-testing-framework/pull/152. Only one of the two should be merged.

This approach provides a plugin for loading images following the standard KTF plugin pattern. Building a cluster that includes this plugin will attempt to load an image and report a failure if that is not possible or if that is unsuccessful.

This addition lacks tests because KIND will not (contrary to my earlier expectations) load an image not already present on the host machine. We'd need to run `docker pull` or similar to ensure the requested image is available locally, and I'm loathe to screw around with that. My original test code is available at https://gist.github.com/rainest/079d07206913398acf65371703cecf0d

**Pro/con evaluation**

The argument against this approach is that we should not add cluster addons unless they are universally available on all clusters types.

I am in favor of this option:

- I don't see an obvious reason to impose this restriction so long as we can provide feedback indicating that an addon is unavailable. While this case deals with cluster types, it seems reasonable that we'd extend the same paradigm to cluster versions (e.g. a GWAPI addon would not be available on 1.16, but would be available on {future version}). Addons are by definition not mandatory, and users can always simply not include them if they are unavailable on the desired cluster type.
- Using the addon pattern allows us to establish a standard means of requesting an addon reporting availability that works regardless of your target cluster. We currently [return an error in `Deploy()`](https://github.com/Kong/kubernetes-testing-framework/blob/67eb46f5f7dbf0794287f90edfec18beb8062d31/pkg/clusters/addons/metallb/metallb.go#L53) for unavailability. Code that utilizes these is cluster agnostic: you always call `WithAddons(<instance>)`, which always reports any failures when calling `Build()`. If you have multiple cluster types that support an addon set, swapping out the cluster type only requires calling a different package's `New()` function and passing the resulting `Cluster` downstream. If you go with #152's approach, any test that requires a non-universal plugin must be written for the specific target cluster type.
- In this specific case, loading images is not strictly specific to KIND. Although we don't yet provide a Minikube Cluster implementation, it supports [an almost identical command](https://minikube.sigs.k8s.io/docs/handbook/pushing/#7-loading-directly-to-in-cluster-container-runtime). Loading images into GKE arguably isn't impossible, it's just much more complicated (you'd need to ensure GCR is enabled, push an image to it, and provide the new GCR image name to the user) and not something I needed for now.
- Although I can't think of an example offhand, it seems reasonable that we may create addons that have partial support for some clusters, and the `Build() -> Deploy() -> succeed or fail based on availability` paradigm seems like it'd handle this easily.

We should look at more robust means of handling support indications if we think `Deploy()` failures are insufficient, but I think having a generic interface for attempting to load addons is far preferable to having separate paradigms for similar tasks (enabling functionality not exposed by the base Cluster functions), one of which is incapable of sharing both implementation and user-written test code.