### PR TITLE
feat: add load image KIND helper

### DIFF
--- a/pkg/clusters/types/kind/cluster.go
+++ b/pkg/clusters/types/kind/cluster.go
@@ -1,9 +1,12 @@
 package kind
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 
@@ -139,6 +142,26 @@ func (c *kindCluster) DeleteAddon(ctx context.Context, addon clusters.Addon) err
 	}
 
 	delete(c.addons, addon.Name())
+
+	return nil
+}
+
+// LoadImage takes a cluster name and image name and uses the KIND CLI to load that image into the cluster
+func LoadImage(clusterName, image string) error {
+	deployArgs := []string{
+		"load", "docker-image",
+		image,
+		"--name", clusterName,
+	}
+
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("kind", deployArgs...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", stderr.String(), err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This is one of two proposals to add image loading to KTF, broken out of #149. It is mutually exclusive with https://github.com/Kong/kubernetes-testing-framework/pull/151. Only one of the two should be merged. Pro/con discussion is in #151.

This approach makes `LoadImage()` a function in the KTF `kind` package. Ensuring that the test cluster is a KIND cluster and that the named cluster is the KIND cluster used for testing is delegated to the library user.

This addition lacks tests because KIND will not (contrary to my earlier expectations) load an image not already present on the host machine. We'd need to run `docker pull` or similar to ensure the requested image is available locally, and I'm loathe to screw around with that.