### PR TITLE
chore: update knative addon to v1.0.1

### DIFF
--- a/test/integration/clusterutils_test.go
+++ b/test/integration/clusterutils_test.go
@@ -70,7 +70,7 @@ func TestClusterUtils(t *testing.T) {
 				deployment, err := env.Cluster().Client().AppsV1().Deployments(namespace.Name).Get(ctx, "httpbin", metav1.GetOptions{})
 				require.NoError(t, err)
 				return deployment.Status.AvailableReplicas == *deployment.Spec.Replicas
-			}, time.Minute*3, time.Second)
+			}, time.Minute*5, time.Second)
 		}
 	}
 


### PR DESCRIPTION
Knative now has a `1.0.x` release, so this patch updates our addon to use it.