### PR TITLE
Add a TLS TCP port 8899 to Kong addon

### DIFF
--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -376,6 +376,10 @@ func exposePortsDefault() []string {
 		"--set", "proxy.stream[1].servicePort=9999",
 		"--set", "proxy.stream[1].parameters[0]=udp",
 		"--set", "proxy.stream[1].parameters[1]=reuseport",
+		"--set", "proxy.stream[1].containerPort=8899",
+		"--set", "proxy.stream[1].servicePort=8899",
+		"--set", "proxy.stream[1].parameters[0]=ssl",
+		"--set", "proxy.stream[1].parameters[1]=reuseport",
 	}
 }
 


### PR DESCRIPTION
We're going to need to test some TLS route stuff, thus...