### PR TITLE
fix: allow extra replicas for availability

### DIFF
--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -64,7 +64,7 @@ func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	var waitingForObjects []runtime.Object
 	for i := 0; i < len(deploymentList.Items); i++ {
 		deployment := &(deploymentList.Items[i])
-		if deployment.Status.AvailableReplicas != *deployment.Spec.Replicas {
+		if deployment.Status.AvailableReplicas < *deployment.Spec.Replicas {
 			waitingForObjects = append(waitingForObjects, deployment)
 		}
 	}


### PR DESCRIPTION
It's technically possible at times for the available
replica count to be higher than the replicas desired
in the spec, but this should not stop addon readiness.

This resolves #172 