### PR TITLE
Bump Enterprise to 2.7 and release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.11.1
+
+### Improvements
+
+- The default Kong Enterprise tag is now `2.7.0.0-alpine`.
+
 ## v0.11.0
 
 ### Bug Fixes

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -35,7 +35,7 @@ const (
 	DefaultEnterpriseImageRepo = "kong/kong-gateway"
 
 	// DefaultEnterpriseImageTag latest kong enterprise image tag
-	DefaultEnterpriseImageTag = "2.5.0.0-alpine"
+	DefaultEnterpriseImageTag = "2.7.0.0-alpine"
 
 	// DefaultEnterpriseLicenseSecretName is the name that will be used by default for the
 	// Kubernetes secret containing the Kong enterprise license that will be


### PR DESCRIPTION
Needed to fix https://github.com/Kong/kubernetes-ingress-controller/issues/2126

Tests that delete and restore their upstreams in non-default workspaces may be affected by the upstream event fix in https://docs.konghq.com/gateway/changelog/#core-6