### PR TITLE
feat(knative) support user-supplied versions

### DIFF
--- a/pkg/clusters/addons/knative/builder.go
+++ b/pkg/clusters/addons/knative/builder.go
@@ -1,0 +1,31 @@
+package knative
+
+import (
+	"errors"
+)
+
+// Builder constructs a knative addon
+type Builder struct {
+	version string
+}
+
+// NewBuilder returns a new Builder
+func NewBuilder() *Builder {
+	return &Builder{version: DefaultVersion}
+}
+
+// WithVersion sets the addon version
+func (b *Builder) WithVersion(version string) (*Builder, error) {
+	if len(version) == 0 {
+		return nil, errors.New("no version provided")
+	}
+	b.version = version
+	return b, nil
+}
+
+// Build creates a knative addon using the builder parameters
+func (b *Builder) Build() *addon {
+	return &addon{
+		version: b.version,
+	}
+}

--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -232,7 +232,7 @@ func deleteKnative(ctx context.Context, cluster clusters.Cluster, version string
 	}
 }
 
-// useLatestKnativeVersion locates and sets the istio version to deploy to the latest
+// useLatestKnativeVersion locates and sets the knative version to deploy to the latest
 // non-prelease tag found.
 func (a *addon) useLatestKnativeVersion() error {
 	latestVersion, err := github.FindLatestReleaseForRepo("knative", "serving")

--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -235,10 +235,10 @@ func deleteKnative(ctx context.Context, cluster clusters.Cluster, version string
 // useLatestKnativeVersion locates and sets the knative version to deploy to the latest
 // non-prelease tag found.
 func (a *addon) useLatestKnativeVersion() error {
-	latestVersion, err := github.FindLatestReleaseForRepo("knative", "serving")
+	latestVersion, err := github.FindRawLatestReleaseForRepo("knative", "serving")
 	if err != nil {
 		return err
 	}
-	a.version = latestVersion.String()
+	a.version = latestVersion
 	return nil
 }


### PR DESCRIPTION
Support user-supplied Knative versions, and default to the latest release at this time.

Basic PoC using the controller integration tests:

[knative_test.txt](https://github.com/Kong/kubernetes-testing-framework/files/7899557/knative_test.txt)

```
10:08:55-0800 esenin $ kubectl describe po -n knative-serving | grep release=
                serving.knative.dev/release=v1.1.1
```