### PR TITLE
fix(knative) add retry to core deployment

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,19 +15,6 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-    - name: setup golang
-      uses: actions/setup-go@v2
-      with:
-        go-version: '^1.17'
-
-    - name: cache go modules
-      uses: actions/cache@v2.1.7
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-build-codegen-
-
     - name: checkout repository
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Fix #208 using something sort of like `require.Eventually()`

Fix is speculative based on the observed issue. We have no guaranteed means of reproducing the issue to confirm.