### PR TITLE
feat: expose default TCP port for Kong addon

### DIFF
--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -376,8 +376,8 @@ func exposePortsDefault() []string {
 		"--set", fmt.Sprintf("proxy.stream[1].servicePort=%d", DefaultUDPServicePort),
 		"--set", "proxy.stream[1].parameters[0]=udp",
 		"--set", "proxy.stream[1].parameters[1]=reuseport",
-		"--set", "proxy.stream[2].containerPort=8899",
-		"--set", "proxy.stream[2].servicePort=8899",
+		"--set", fmt.Sprintf("proxy.stream[2].containerPort=%d", DefaultTLSServicePort),
+		"--set", fmt.Sprintf("proxy.stream[2].servicePort=%d", DefaultTLSServicePort),
 		"--set", "proxy.stream[2].parameters[0]=ssl",
 		"--set", "proxy.stream[2].parameters[1]=reuseport",
 	}

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -370,10 +370,10 @@ func enterpriseDefaults() []string {
 // test cases to use these how they see fit AND clean up after themselves.
 func exposePortsDefault() []string {
 	return []string{
-		"--set", "proxy.stream[0].containerPort=8888",
-		"--set", "proxy.stream[0].servicePort=8888",
-		"--set", "proxy.stream[1].containerPort=9999",
-		"--set", "proxy.stream[1].servicePort=9999",
+		"--set", fmt.Sprintf("proxy.stream[0].containerPort=%d", DefaultTCPServicePort),
+		"--set", fmt.Sprintf("proxy.stream[0].servicePort=%d", DefaultTCPServicePort),
+		"--set", fmt.Sprintf("proxy.stream[1].containerPort=%d", DefaultUDPServicePort),
+		"--set", fmt.Sprintf("proxy.stream[1].servicePort=%d", DefaultUDPServicePort),
 		"--set", "proxy.stream[1].parameters[0]=udp",
 		"--set", "proxy.stream[1].parameters[1]=reuseport",
 		"--set", "proxy.stream[2].containerPort=8899",

--- a/pkg/clusters/addons/kong/vars.go
+++ b/pkg/clusters/addons/kong/vars.go
@@ -45,7 +45,7 @@ const (
 
 	// DefaultTCPServicePort indicates the default open port that will be used for TCP traffic.
 	DefaultTCPServicePort = 8888
-	
+
 	// DefaultTLSServicePort indicates the default open port that will be used for TLS traffic.
 	DefaultTLSServicePort = 8899
 )

--- a/pkg/clusters/addons/kong/vars.go
+++ b/pkg/clusters/addons/kong/vars.go
@@ -43,6 +43,9 @@ const (
 	// DefaultUDPServicePort indicates the default open port to be found on the Kong proxy's UDP service.
 	DefaultUDPServicePort = 9999
 
-	// DefaultUDPServicePort indicates the default open port that will be used for TCP traffic.
+	// DefaultTCPServicePort indicates the default open port that will be used for TCP traffic.
 	DefaultTCPServicePort = 8888
+	
+	// DefaultTLSServicePort indicates the default open port that will be used for TLS traffic.
+	DefaultTLSServicePort = 8899
 )

--- a/pkg/clusters/addons/kong/vars.go
+++ b/pkg/clusters/addons/kong/vars.go
@@ -42,4 +42,7 @@ const (
 
 	// DefaultUDPServicePort indicates the default open port to be found on the Kong proxy's UDP service.
 	DefaultUDPServicePort = 9999
+
+	// DefaultUDPServicePort indicates the default open port that will be used for TCP traffic.
+	DefaultTCPServicePort = 8888
 )


### PR DESCRIPTION
Exposes the default TCP routing port for the Kong Addon as a far, similar to what already exists for UDP. Also adds references to the var instead of literals where applicable.

Needed for https://github.com/Kong/kubernetes-ingress-controller/issues/2086