### PR TITLE
feat(Makefile): add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ build:
 	mkdir -p build/
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o build/ktf.$(GOOS).$(GOARCH) cmd/ktf/main.go
 
+.PHONY: install
+install:
+	go install ./cmd/ktf
+
 .PHONY: lint
 lint:
 	@golangci-lint run ./...


### PR DESCRIPTION
This PR adds an `install` makefile target to easy installing in-tree version system-wide.