### PR TITLE
fix: remove cluster init token check

### DIFF
--- a/internal/utils/cluster_init.go
+++ b/internal/utils/cluster_init.go
@@ -55,25 +55,6 @@ func ClusterInitHooks(ctx context.Context, cluster clusters.Cluster) error {
 		}
 	}
 
-	// ensure the secret token for the default sa is available
-	var defaultSATokenReady bool
-	for !defaultSATokenReady {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context completed before cluster init hooks could finish: %w", ctx.Err())
-		default:
-			defaultSA, err = cluster.Client().CoreV1().ServiceAccounts(namespace.Name).Get(ctx, defaultSA.Name, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			if len(defaultSA.Secrets) > 0 {
-				defaultSATokenReady = true
-			} else {
-				time.Sleep(time.Second)
-			}
-		}
-	}
-
 	// give the default SA in this namespace cluster admin
 	crb := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Back when we first made KTF we added a check to wait for the service account that would be used for testing until it's `Secret` was generated. Modern versions of Kubernetes since `v1.24.0` have a different implementation for `ServiceAccounts` which doesn't make this secret available like it used to be. As such this patch removes the check as it is irrelevant going forward and is breaking recent deployments.