### PR TITLE
feat: add kong-ingress-controller-image flag

### DIFF
--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -64,6 +64,8 @@ type Addon struct {
 
 	// ingress controller configuration options
 	ingressControllerDisabled bool
+	ingressControllerImage    string
+	ingressControllerImageTag string
 
 	// proxy server general configuration options
 	proxyAdminServiceTypeLoadBalancer bool
@@ -207,6 +209,14 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 			"--set", "ingressController.installCRDs=false",
 			"--skip-crds",
 		}...)
+	}
+
+	// set the ingress controller container image values if provided by the caller
+	if a.ingressControllerImage != "" {
+		a.deployArgs = append(a.deployArgs, []string{"--set", fmt.Sprintf("ingressController.image.repository=%s", a.ingressControllerImage)}...)
+	}
+	if a.ingressControllerImageTag != "" {
+		a.deployArgs = append(a.deployArgs, []string{"--set", fmt.Sprintf("ingressController.image.tag=%s", a.ingressControllerImageTag)}...)
 	}
 
 	// set the container image values if provided by the caller

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -117,8 +117,7 @@ func (b *Builder) WithProxyImage(repo, tag string) *Builder {
 	return b
 }
 
-// WithControllerImage configures the ingress controller
-// container image name and tag for the Kong proxy.
+// WithControllerImage configures the ingress controller container image name and tag.
 func (b *Builder) WithControllerImage(repo, tag string) *Builder {
 	b.ingressControllerImage = repo
 	b.ingressControllerImageTag = tag

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -21,6 +21,8 @@ type Builder struct {
 
 	// ingress controller configuration options
 	ingressControllerDisabled bool
+	ingressControllerImage    string
+	ingressControllerImageTag string
 
 	// proxy server general configuration options
 	proxyAdminServiceTypeLoadBalancer bool
@@ -68,6 +70,8 @@ func (b *Builder) Build() *Addon {
 		deployArgs: b.deployArgs,
 
 		ingressControllerDisabled: b.ingressControllerDisabled,
+		ingressControllerImage:    b.ingressControllerImage,
+		ingressControllerImageTag: b.ingressControllerImageTag,
 
 		proxyAdminServiceTypeLoadBalancer: b.proxyAdminServiceTypeLoadBalancer,
 		proxyDBMode:                       b.proxyDBMode,
@@ -110,6 +114,14 @@ func (b *Builder) WithPostgreSQL() *Builder {
 func (b *Builder) WithProxyImage(repo, tag string) *Builder {
 	b.proxyImage = repo
 	b.proxyImageTag = tag
+	return b
+}
+
+// WithControllerImage configures the ingress controller
+// container image name and tag for the Kong proxy.
+func (b *Builder) WithControllerImage(repo, tag string) *Builder {
+	b.ingressControllerImage = repo
+	b.ingressControllerImageTag = tag
 	return b
 }
 

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -1,0 +1,82 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kongaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
+	environment "github.com/kong/kubernetes-testing-framework/pkg/environments"
+)
+
+type customImageTest struct {
+	controllerImageRepo string
+	controllerImageTag  string
+	proxyImageRepo      string
+	proxyImageTag       string
+}
+
+func (tc customImageTest) controllerImage() string {
+	return fmt.Sprintf("%s:%s", tc.controllerImageRepo, tc.controllerImageTag)
+}
+
+func (tc customImageTest) proxyImage() string {
+	return fmt.Sprintf("%s:%s", tc.proxyImageRepo, tc.proxyImageTag)
+}
+
+func (tc customImageTest) name() string {
+	return fmt.Sprintf("KongAddonImages:[%s,%s]", tc.controllerImage(), tc.proxyImage())
+}
+
+func TestKongAddontWithCustomImage(t *testing.T) {
+	tests := []customImageTest{
+		{"kong/kubernetes-ingress-controller", "2.3.0", "kong", "2.7"},
+		{"kong/kubernetes-ingress-controller", "2.3.1", "kong", "2.8"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name(), func(t *testing.T) {
+			t.Parallel()
+			testKongAddonWithCustomImage(t, tc)
+		})
+	}
+}
+
+func testKongAddonWithCustomImage(t *testing.T, tc customImageTest) {
+	t.Log("configuring kong addon with custom images")
+	kong := kongaddon.NewBuilder().
+		WithProxyImage(tc.proxyImageRepo, tc.proxyImageTag).
+		WithControllerImage(tc.controllerImageRepo, tc.controllerImageTag).
+		Build()
+
+	t.Log("configuring the testing environment")
+	builder := environment.NewBuilder().WithAddons(kong)
+
+	t.Log("building the testing environment and Kubernetes cluster")
+	env, err := builder.Build(ctx)
+	require.NoError(t, err)
+
+	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())
+	defer func() {
+		t.Logf("cleaning up environment %s and cluster %s", env.Name(), env.Cluster().Name())
+		require.NoError(t, env.Cleanup(ctx))
+	}()
+
+	t.Log("verifying that addons have been loaded into the environment")
+	require.Len(t, env.Cluster().ListAddons(), 1)
+
+	t.Log("verifying that the kong deployment is using custom images")
+	deployments := env.Cluster().Client().AppsV1().Deployments(kong.Namespace())
+	kongDeployment, err := deployments.Get(ctx, "ingress-controller-kong", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, kongDeployment.Spec.Template.Spec.Containers, 2)
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[0].Name, "ingress-controller")
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[1].Name, "proxy")
+	require.Contains(t, kongDeployment.Spec.Template.Spec.Containers[0].Image, tc.controllerImage())
+	require.Contains(t, kongDeployment.Spec.Template.Spec.Containers[1].Image, tc.proxyImage())
+}

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -35,8 +35,18 @@ func (tc customImageTest) name() string {
 
 func TestKongAddontWithCustomImage(t *testing.T) {
 	tests := []customImageTest{
-		{"kong/kubernetes-ingress-controller", "2.3.0", "kong", "2.7"},
-		{"kong/kubernetes-ingress-controller", "2.3.1", "kong", "2.8"},
+		{
+			controllerImageRepo: "kong/kubernetes-ingress-controller",
+			controllerImageTag:  "2.3.0",
+			proxyImageRepo:      "kong",
+			proxyImageTag:       "2.7",
+		},
+		{
+			controllerImageRepo: "kong/kubernetes-ingress-controller",
+			controllerImageTag:  "2.3.1",
+			proxyImageRepo:      "kong",
+			proxyImageTag:       "2.8",
+		},
 	}
 
 	for _, tc := range tests {
@@ -77,6 +87,6 @@ func testKongAddonWithCustomImage(t *testing.T, tc customImageTest) {
 	require.Len(t, kongDeployment.Spec.Template.Spec.Containers, 2)
 	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[0].Name, "ingress-controller")
 	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[1].Name, "proxy")
-	require.Contains(t, kongDeployment.Spec.Template.Spec.Containers[0].Image, tc.controllerImage())
-	require.Contains(t, kongDeployment.Spec.Template.Spec.Containers[1].Image, tc.proxyImage())
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[0].Image, tc.controllerImage())
+	require.Equal(t, kongDeployment.Spec.Template.Spec.Containers[1].Image, tc.proxyImage())
 }

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -33,7 +33,7 @@ func (tc customImageTest) name() string {
 	return fmt.Sprintf("KongAddonImages:[%s,%s]", tc.controllerImage(), tc.proxyImage())
 }
 
-func TestKongAddontWithCustomImage(t *testing.T) {
+func TestKongAddonWithCustomImage(t *testing.T) {
 	tests := []customImageTest{
 		{
 			controllerImageRepo: "kong/kubernetes-ingress-controller",


### PR DESCRIPTION
This PR adds kong-ingress-controller-image that sets the ingress controller image used for deployment.