### PR TITLE
feat(gke) disable Google Ingress controller

### DIFF
--- a/pkg/clusters/types/gke/builder.go
+++ b/pkg/clusters/types/gke/builder.go
@@ -88,8 +88,11 @@ func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 	pbcluster := containerpb.Cluster{
 		Name:             b.Name,
 		InitialNodeCount: 1,
-		AddonsConfig:     &containerpb.AddonsConfig{}, // empty config to indicate that no addons are desired
-		ResourceLabels:   map[string]string{GKECreateLabel: createdByID},
+		// disable the GKE ingress controller, which will otherwise interact with classless Ingresses
+		AddonsConfig: &containerpb.AddonsConfig{
+			HttpLoadBalancing: &containerpb.HttpLoadBalancing{Disabled: true},
+		},
+		ResourceLabels: map[string]string{GKECreateLabel: createdByID},
 	}
 	req := containerpb.CreateClusterRequest{Parent: parent, Cluster: &pbcluster}
 


### PR DESCRIPTION
Disable the GKE native Ingress controller. This controller interacts with classless Ingresses, which can interfere with our tests.

We encountered an apparent race condition where https://github.com/Kong/kubernetes-ingress-controller/blob/main/test/integration/ingress_test.go#L330 failed because the resource had been updated after we got it, blocking our update. It's not actually clear if the classless interactions are the cause here--they shouldn't be because the failure was the update to make the resource classless. However, the only unexpected configuration I can see on the Ingress is related to the GKE controller, so absent other explanations, figured it was worth a shot.

Test KIC run in https://github.com/Kong/kubernetes-ingress-controller/pull/2634. Note that while the additional temporary GKE tests I added to integration passed, this isn't really a guarantee that my hypothesis and fix are correct, since the issue flakes. It's maybe more to demonstrate that this change doesn't break existing functionality.

Haven't added a toggle to flip this: ALL KTF instances will have this disabled. The original comment indicated we wanted no addons, but there are some on by default, so an addons object that doesn't explicitly disable those will include those addons. Disabling this without a toggle felt aligned with the original intent. Let me know if we want to make this something you can toggle.