### PR TITLE
chore(ci): use kong-license action to obtain license from pulp

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -17,6 +17,10 @@ jobs:
     environment: gcloud
     runs-on: ubuntu-latest
     steps:
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        password: ${{ secrets.PULP_PASSWORD }}
 
     # --------------------------------------------------------------------------
     # Repository Checkout
@@ -51,7 +55,7 @@ jobs:
     - name: run integration tests
       run: make test.integration
       env:
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
     - name: run e2e tests
       run: make test.e2e
@@ -59,7 +63,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
         GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
     # --------------------------------------------------------------------------
     # Release Tagging

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,11 @@ jobs:
     environment: "integration-tests"
     runs-on: ubuntu-latest
     steps:
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        password: ${{ secrets.PULP_PASSWORD }}
+
     - name: setup golang
       uses: actions/setup-go@v3
       with:
@@ -40,7 +45,7 @@ jobs:
       env:
         KTF_TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         KTF_TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
-        KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         NCPU: 2 # it was found that github actions (specifically) did not seem to perform well when spawning
                 # multiple kind clusters within a single job so this is hardcoded to 2 to ensure a limit of 2 clusters at any one point.
 


### PR DESCRIPTION
At the same time I've added `PULP_PASSWORD` secret to Dependabot's secrets and to `integration-tests` environment secrets.