### PR TITLE
feat: add calico CNI option for kind clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- `ApplyYAML` and `DeleteYAML` cluster utilities were renamed to
+  `ApplyManifestByYAML` and `DeleteManifestByYAML`, respectively.
+  [#330](https://github.com/Kong/kubernetes-testing-framework/pull/330)
+
+### Added
+
+- Added the ability to use Calico CNI instead of the default CNI for `kind`
+  clusters. This can be triggered via the CLI using `--cni-calico` OR using the
+  Go library with `WithCalicoCNI()`.
+  [#330](https://github.com/Kong/kubernetes-testing-framework/pull/330)
+- Added `ApplyManifestByURL` and `DeleteManifestByURL` helper functions to the
+  `cluster` package as siblings to `ApplyYAML` and `DeleteYAML`.
+  [#330](https://github.com/Kong/kubernetes-testing-framework/pull/330)
+
 ## v0.16.0
 
 - Added `WithProxyImagePullSecret()` (`proxy-pull` with

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	k8s.io/cli-runtime v0.24.3
 	k8s.io/kubectl v0.24.3
 	sigs.k8s.io/controller-runtime v0.12.3
+	sigs.k8s.io/kind v0.14.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -90,6 +91,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -182,6 +184,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
@@ -381,6 +384,7 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jetstack/cert-manager v1.7.2 h1:kDme6/AtdCgLupnB1qrAOxFCoM7ahtt+Y9DNQXZXIkA=
 github.com/jetstack/cert-manager v1.7.2/go.mod h1:xj0TPp31HE0Jub5mNOnF3Fp3XvhIsiP+tsPZVOmU/Qs=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -430,6 +434,7 @@ github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
@@ -492,6 +497,7 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
@@ -1258,6 +1264,8 @@ sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
+sigs.k8s.io/kind v0.14.0 h1:cNmI3jGBvp7UegEGbC5we8plDtCUmaNRL+bod7JoSCE=
+sigs.k8s.io/kind v0.14.0/go.mod h1:UrFRPHG+2a5j0Q7qiR4gtJ4rEyn8TuMQwuOPf+m4oHg=
 sigs.k8s.io/kustomize/api v0.11.4 h1:/0Mr3kfBBNcNPOW5Qwk/3eb8zkswCwnqQxxKtmrTkRo=
 sigs.k8s.io/kustomize/api v0.11.4/go.mod h1:k+8RsqYbgpkIrJ4p9jcdPqe8DprLxFUUO0yNOq8C+xI=
 sigs.k8s.io/kustomize/cmd/config v0.10.6/go.mod h1:/S4A4nUANUa4bZJ/Edt7ZQTyKOY9WCER0uBS1SW2Rco=

--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -46,6 +46,7 @@ func init() { //nolint:gochecknoinits
 
 	// cluster configurations
 	environmentsCreateCmd.PersistentFlags().String("kubernetes-version", "", "which kubernetes version to use (default: latest for driver)")
+	environmentsCreateCmd.PersistentFlags().Bool("cni-calico", false, "use Calico for cluster CNI instead of the default CNI")
 
 	// addon configurations
 	environmentsCreateCmd.PersistentFlags().StringArray("addon", nil, "name of an addon to deploy to the testing environment's cluster")
@@ -79,10 +80,17 @@ var environmentsCreateCmd = &cobra.Command{
 		kubernetesVersion, err := cmd.PersistentFlags().GetString("kubernetes-version")
 		cobra.CheckErr(err)
 
+		// check if Calico CNI was requested
+		useCalicoCNI, err := cmd.PersistentFlags().GetBool("cni-calico")
+		cobra.CheckErr(err)
+
 		// setup the new environment
 		builder := environments.NewBuilder()
 		if !useGeneratedName {
 			builder = builder.WithName(name)
+		}
+		if useCalicoCNI {
+			builder = builder.WithCalicoCNI()
 		}
 		if kubernetesVersion != "" {
 			version, err := semver.Parse(strings.TrimPrefix(kubernetesVersion, "v"))

--- a/pkg/clusters/addons/certmanager/addon.go
+++ b/pkg/clusters/addons/certmanager/addon.go
@@ -206,14 +206,14 @@ spec:
 )
 
 func (a *Addon) deployDefaultIssuer(ctx context.Context, cluster clusters.Cluster) error {
-	if err := clusters.ApplyYAML(ctx, cluster, defaultIssuer); err != nil {
+	if err := clusters.ApplyManifestByYAML(ctx, cluster, defaultIssuer); err != nil {
 		return err
 	}
 	return clusters.WaitForCondition(ctx, cluster, DefaultNamespace, "clusterissuers.cert-manager.io", DefaultIssuerName, "Ready", defaultIssuerWaitSeconds)
 }
 
 func (a *Addon) cleanupDefaultIssuer(ctx context.Context, cluster clusters.Cluster) error {
-	return clusters.DeleteYAML(ctx, cluster, defaultIssuer)
+	return clusters.DeleteManifestByYAML(ctx, cluster, defaultIssuer)
 }
 
 const webhookWaitJobName = "cert-manager-webhook-wait"

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -222,7 +222,7 @@ spec:
 // startup
 func (a *Addon) enableMTLS(ctx context.Context, cluster clusters.Cluster) (err error) {
 	for i := 0; i < 5; i++ {
-		err = clusters.ApplyYAML(ctx, cluster, mtlsEnabledDefaultMesh)
+		err = clusters.ApplyManifestByYAML(ctx, cluster, mtlsEnabledDefaultMesh)
 		if err != nil {
 			time.Sleep(time.Second * 5) //nolint:gomnd
 		} else {

--- a/pkg/clusters/types/kind/utils.go
+++ b/pkg/clusters/types/kind/utils.go
@@ -9,9 +9,11 @@ import (
 	"os/exec"
 	"sync"
 
+	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 )
@@ -34,6 +36,14 @@ func NewFromExisting(name string) (clusters.Cluster, error) {
 		addons: make(clusters.Addons),
 	}, nil
 }
+
+// -----------------------------------------------------------------------------
+// Private Consts & Vars
+// -----------------------------------------------------------------------------
+
+const (
+	defaultCalicoManifests = "https://projectcalico.docs.tigera.io/manifests/calico.yaml"
+)
 
 // -----------------------------------------------------------------------------
 // Private Functions - Cluster Management
@@ -89,4 +99,54 @@ func clientForCluster(name string) (*rest.Config, *kubernetes.Clientset, error) 
 
 	clientset, err := kubernetes.NewForConfig(cfg)
 	return cfg, clientset, err
+}
+
+const defaultKindConfig = `---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+`
+
+func (b *Builder) ensureConfigFile() error {
+	if b.configPath == nil {
+		f, err := os.CreateTemp(os.TempDir(), "ktf-kind-config")
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = f.WriteString(defaultKindConfig)
+		if err != nil {
+			return err
+		}
+
+		filename := f.Name()
+		b.configPath = &filename
+	}
+
+	return nil
+}
+
+func (b *Builder) disableDefaultCNI() error {
+	if err := b.ensureConfigFile(); err != nil {
+		return err
+	}
+
+	configYAML, err := os.ReadFile(*b.configPath)
+	if err != nil {
+		return err
+	}
+
+	kindConfig := v1alpha4.Cluster{}
+	if err := yaml.Unmarshal(configYAML, &kindConfig); err != nil {
+		return err
+	}
+
+	kindConfig.Networking.DisableDefaultCNI = true
+
+	configYAML, err = yaml.Marshal(kindConfig)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(*b.configPath, configYAML, 0600) //nolint:gomnd
 }

--- a/test/integration/calico_test.go
+++ b/test/integration/calico_test.go
@@ -1,0 +1,154 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/httpbin"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+)
+
+func TestKindClusterWithCalicoCNI(t *testing.T) {
+	t.Parallel()
+
+	t.Log("configuring the test environment with Calico enabled")
+	builder := environments.NewBuilder().WithCalicoCNI().WithAddons(httpbin.New())
+
+	t.Log("building the testing environment and Kubernetes cluster")
+	env, err := builder.Build(ctx)
+	require.NoError(t, err)
+
+	t.Log("waiting for the testing environment to be ready")
+	require.NoError(t, <-env.WaitForReady(ctx))
+	defer env.Cleanup(ctx)
+
+	t.Log("verifying that Calico is running on the cluster")
+	daemonset, err := env.Cluster().Client().AppsV1().DaemonSets("kube-system").Get(ctx, "calico-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Greater(t, daemonset.Status.NumberAvailable, int32(0))
+
+	t.Log("collecting the pod IP of the httpbin addon")
+	httpbinPodIP := ""
+	require.Eventually(t, func() bool {
+		pods, err := env.Cluster().Client().CoreV1().Pods(httpbin.DefaultNamespace).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		for _, pod := range pods.Items {
+			if strings.Contains(pod.Name, "httpbin") {
+				if pod.Status.PodIP != "" {
+					httpbinPodIP = pod.Status.PodIP
+					return true
+				}
+			}
+		}
+		t.Logf("found %d pods in namespace %s, no httpbin pods were found.", len(pods.Items), httpbin.DefaultNamespace)
+		return false
+	}, time.Second*30, time.Second)
+
+	t.Log("verifying cluster network connectivity to the httpbin addon")
+	httpbinURL := fmt.Sprintf("http://%s/status/200", httpbinPodIP)
+	job := generateCURLJob(httpbinURL, 3)
+	job, err = env.Cluster().Client().BatchV1().Jobs(httpbin.DefaultNamespace).Create(ctx, job, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		job, err = env.Cluster().Client().BatchV1().Jobs(httpbin.DefaultNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return job.Status.Succeeded > 0
+	}, time.Minute*3, time.Second)
+
+	t.Log("creating a NetworkPolicy to deny traffic to the httpbin addon")
+	netpol := generateNetPol(string(httpbin.AddonName), "127.0.0.1/32")
+	netpol, err = env.Cluster().Client().NetworkingV1().NetworkPolicies(httpbin.DefaultNamespace).Create(ctx, netpol, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("verifying that traffic to the httpbin addon is denied")
+	job = generateCURLJob(httpbinURL, 1)
+	job, err = env.Cluster().Client().BatchV1().Jobs(httpbin.DefaultNamespace).Create(ctx, job, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		job, err = env.Cluster().Client().BatchV1().Jobs(httpbin.DefaultNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return job.Status.Failed > 0
+	}, time.Minute, time.Second)
+
+	t.Log("removing the NetworkPolicy to allow traffic to the httpbin addon")
+	require.NoError(t, env.Cluster().Client().NetworkingV1().NetworkPolicies(httpbin.DefaultNamespace).Delete(ctx, netpol.Name, metav1.DeleteOptions{}))
+
+	t.Log("verifying that traffic to the httpbin addon now succeeds")
+	job = generateCURLJob(httpbinURL, 3)
+	job, err = env.Cluster().Client().BatchV1().Jobs(httpbin.DefaultNamespace).Create(ctx, job, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		job, err = env.Cluster().Client().BatchV1().Jobs(httpbin.DefaultNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return job.Status.Succeeded > 0
+	}, time.Minute, time.Second)
+}
+
+func generateCURLJob(url string, retries int32) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: batchv1.JobSpec{
+			Completions:           pointer.Int32(1),
+			ActiveDeadlineSeconds: pointer.Int64(10),
+			BackoffLimit:          pointer.Int32(retries),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "curl",
+						Image:   "curlimages/curl",
+						Command: []string{"curl", "-m", "10", url},
+					}},
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+				},
+			},
+		},
+	}
+}
+
+var tcpproto = corev1.ProtocolTCP
+
+func generateNetPol(app string, allowCIDR string) *netv1.NetworkPolicy {
+	return &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": app,
+				},
+			},
+			PolicyTypes: []netv1.PolicyType{
+				netv1.PolicyTypeIngress,
+			},
+			Ingress: []netv1.NetworkPolicyIngressRule{{
+				From: []netv1.NetworkPolicyPeer{{
+					IPBlock: &netv1.IPBlock{
+						CIDR: allowCIDR,
+					},
+				}},
+				Ports: []netv1.NetworkPolicyPort{
+					{
+						Protocol: &tcpproto,
+					},
+				},
+			}},
+		},
+	}
+
+}

--- a/test/integration/certmanager_test.go
+++ b/test/integration/certmanager_test.go
@@ -34,7 +34,7 @@ func TestCertManagerAddon(t *testing.T) {
 	require.NoError(t, <-env.WaitForReady(ctx))
 
 	t.Log("deploying a cert-manager certificate to the cluster")
-	require.NoError(t, clusters.ApplyYAML(ctx, env.Cluster(), `---
+	require.NoError(t, clusters.ApplyManifestByYAML(ctx, env.Cluster(), `---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/test/integration/clusterutils_test.go
+++ b/test/integration/clusterutils_test.go
@@ -145,7 +145,7 @@ metadata:
 data:
   message: "batman"
 `
-	require.NoError(t, clusters.ApplyYAML(ctx, env.Cluster(), cfgmapYAML))
+	require.NoError(t, clusters.ApplyManifestByYAML(ctx, env.Cluster(), cfgmapYAML))
 	cfgmap, err := env.Cluster().Client().CoreV1().ConfigMaps(corev1.NamespaceDefault).Get(ctx, "test-cluster-apply", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "batman", cfgmap.Data["message"])


### PR DESCRIPTION
The purpose of this task is to add [Calico](https://projectcalico.docs.tigera.io) as an alternative CNI option for `kind` clusters as this will enable the validation and testing of `NetworkPolicy` resources.