### PR TITLE
Add diagnostic dump framework

### DIFF
--- a/pkg/clusters/addons.go
+++ b/pkg/clusters/addons.go
@@ -33,6 +33,10 @@ type Addon interface {
 	// Delete removes the addon component from the given cluster.
 	Delete(ctx context.Context, cluster Cluster) error
 
+	// DumpDiagnostics gathers and returns diagnostic information for an addon. Its return map is a map of string
+	// filenames to file content byte slices.
+	DumpDiagnostics(ctx context.Context, cluster Cluster) (map[string][]byte, error)
+
 	// Ready is a non-blocking call which checks the status of the addon on the
 	// cluster and reports any runtime.Objects which are still unresolved.
 	// If all components are ready, this method will return [], true, nil.

--- a/pkg/clusters/addons/certmanager/addon.go
+++ b/pkg/clusters/addons/certmanager/addon.go
@@ -185,6 +185,11 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	return nil, true, nil
 }
 
+func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}
+
 // -----------------------------------------------------------------------------
 // CertManager Addon - Private
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/httpbin/addon.go
+++ b/pkg/clusters/addons/httpbin/addon.go
@@ -154,3 +154,8 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObjects []runtime.Object, ready bool, err error) {
 	return utils.IsNamespaceAvailable(ctx, cluster, a.namespace)
 }
+
+func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}

--- a/pkg/clusters/addons/istio/addon.go
+++ b/pkg/clusters/addons/istio/addon.go
@@ -207,6 +207,11 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 	return utils.IsNamespaceAvailable(ctx, cluster, Namespace)
 }
 
+func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}
+
 // -----------------------------------------------------------------------------
 // Istio Addon - Private Vars & Consts
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -87,6 +87,11 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	return nil, true, nil
 }
 
+func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}
+
 // -----------------------------------------------------------------------------
 // Private Functions & Vars
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -80,6 +80,7 @@ type Addon struct {
 	proxyImage                        string
 	proxyImageTag                     string
 	proxyPullSecret                   pullSecret
+	proxyLogLevel                     string
 
 	// proxy server enterprise mode configuration options
 	proxyEnterpriseEnabled            bool
@@ -282,6 +283,11 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 		a.deployArgs = append(a.deployArgs, []string{"--set", "admin.type=LoadBalancer"}...)
 	} else {
 		a.deployArgs = append(a.deployArgs, []string{"--set", "admin.type=ClusterIP"}...)
+	}
+
+	// set the proxy log level
+	if len(a.proxyLogLevel) > 0 {
+		a.deployArgs = append(a.deployArgs, []string{"--set", "env.log_level", a.proxyLogLevel}...)
 	}
 
 	// deploy licenses and other configurations for enterprise mode

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -30,6 +30,7 @@ type Builder struct {
 	proxyImage                        string
 	proxyImageTag                     string
 	proxyPullSecret                   pullSecret
+	proxyLogLevel                     string
 
 	// proxy server enterprise mode configuration options
 	proxyEnterpriseEnabled            bool
@@ -79,6 +80,7 @@ func (b *Builder) Build() *Addon {
 		proxyImage:                        b.proxyImage,
 		proxyImageTag:                     b.proxyImageTag,
 		proxyPullSecret:                   b.proxyPullSecret,
+		proxyLogLevel:                     b.proxyLogLevel,
 
 		proxyEnterpriseEnabled:            b.proxyEnterpriseEnabled,
 		proxyEnterpriseLicenseJSON:        b.proxyEnterpriseLicenseJSON,
@@ -133,6 +135,12 @@ func (b *Builder) WithProxyImage(repo, tag string) *Builder {
 func (b *Builder) WithControllerImage(repo, tag string) *Builder {
 	b.ingressControllerImage = repo
 	b.ingressControllerImageTag = tag
+	return b
+}
+
+//WithLogLevel sets the proxy log level
+func (b *Builder) WithLogLevel(level string) *Builder {
+	b.proxyLogLevel = level
 	return b
 }
 

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -191,6 +191,11 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 	return utils.IsNamespaceAvailable(ctx, cluster, Namespace)
 }
 
+func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}
+
 // -----------------------------------------------------------------------------
 // Kuma Addon - Private Methods
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/loadimage/addon.go
+++ b/pkg/clusters/addons/loadimage/addon.go
@@ -70,3 +70,8 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	// no way to verify this, we rely on Deploy's cmd.Run() not failing
 	return nil, a.loaded, nil
 }
+
+func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -107,6 +107,11 @@ func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	return nil, true, nil
 }
 
+func (a *addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}
+
 // -----------------------------------------------------------------------------
 // Private Types, Constants & Vars
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/registry/addon.go
+++ b/pkg/clusters/addons/registry/addon.go
@@ -451,3 +451,8 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObjects []runtime.Object, ready bool, err error) {
 	return utils.IsNamespaceAvailable(ctx, cluster, Namespace)
 }
+
+func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}

--- a/pkg/clusters/cleanup.go
+++ b/pkg/clusters/cleanup.go
@@ -2,6 +2,10 @@ package clusters
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +42,144 @@ func (c *Cleaner) Add(obj client.Object) {
 
 func (c *Cleaner) AddNamespace(namespace *corev1.Namespace) {
 	c.namespaces = append(c.namespaces, namespace)
+}
+
+// DumpDiagnostics gathers a wide range of diagnostic information from the test cluster, to provide a snapshot of it
+// at a given time for offline debugging. It uses the provided context and writes the meta string to meta.txt to
+// identify the result set.
+func (c *Cleaner) DumpDiagnostics(ctx context.Context, meta string) (string, error) {
+	// Obtain a kubeconfig
+	kubeconfig, err := TempKubeconfig(c.cluster)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(kubeconfig.Name())
+
+	// create a tempdir
+	output, err := os.MkdirTemp(os.TempDir(), "ktf-diag-")
+	if err != nil {
+		return "", err
+	}
+
+	// kubectl get all --all-namespaces -oyaml
+	getAllOut, err := os.Create(filepath.Join(output, "kubectl_get_all.yaml"))
+	if err != nil {
+		return output, err
+	}
+	defer getAllOut.Close()
+	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig.Name(), "get", "all", "--all-namespaces", "-o", "yaml") //nolint:gosec
+	cmd.Stdout = getAllOut
+	if err := cmd.Run(); err != nil {
+		return output, err
+	}
+
+	// kubectl describe all --all-namespaces
+	describeAllOut, err := os.Create(filepath.Join(output, "kubectl_describe_all.txt"))
+	if err != nil {
+		return output, err
+	}
+	cmd = exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig.Name(), "get", "all", "--all-namespaces", "-o", "yaml") //nolint:gosec
+	cmd.Stdout = describeAllOut
+	if err := cmd.Run(); err != nil {
+		return output, err
+	}
+	defer describeAllOut.Close()
+
+	// for each Pod, run kubectl logs
+	pods, err := c.cluster.Client().CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return output, err
+	}
+	logsDir := filepath.Join(output, "pod_logs")
+	err = os.Mkdir(logsDir, 0750) //nolint:gomnd
+	if err != nil {
+		return output, err
+	}
+	failedPods := make(map[string]error)
+	for _, pod := range pods.Items {
+		podLogOut, err := os.Create(filepath.Join(logsDir, fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)))
+		if err != nil {
+			failedPods[fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)] = err
+			continue
+		}
+		cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig.Name(), "logs", "-n", pod.Namespace, pod.Name) //nolint:gosec
+		cmd.Stdout = podLogOut
+		if err := cmd.Run(); err != nil {
+			failedPods[fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)] = err
+			continue
+		}
+		defer podLogOut.Close()
+	}
+	if len(failedPods) > 0 {
+		failedPodOut, err := os.Create(filepath.Join(output, "pod_logs_failures.txt"))
+		if err != nil {
+			return output, err
+		}
+		defer failedPodOut.Close()
+		for failed, reason := range failedPods {
+			_, err = failedPodOut.WriteString(fmt.Sprintf("%s: %v\n", failed, reason))
+			if err != nil {
+				return output, err
+			}
+		}
+	}
+
+	// for each Addon, run the addon diagnostic function
+	failedAddons := make(map[string]error)
+	for _, addon := range c.cluster.ListAddons() {
+		diagnostics, err := addon.DumpDiagnostics(ctx, c.cluster)
+		if err != nil {
+			failedAddons[string(addon.Name())] = err
+			continue
+		}
+		if len(diagnostics) > 0 {
+			addonOut := filepath.Join(output, "addons", string(addon.Name()))
+			err = os.MkdirAll(addonOut, 0750) //nolint:gomnd
+			if err != nil {
+				failedAddons[string(addon.Name())] = err
+				continue
+			}
+			for filename, content := range diagnostics {
+				diagOut, err := os.Create(filepath.Join(addonOut, filename))
+				if err != nil {
+					failedAddons[string(addon.Name())] = err
+					continue
+				}
+				defer diagOut.Close()
+				_, err = diagOut.Write(content)
+				if err != nil {
+					failedAddons[string(addon.Name())] = err
+					continue
+				}
+			}
+		}
+	}
+	if len(failedAddons) > 0 {
+		failedAddonOut, err := os.Create(filepath.Join(output, "addon_failures.txt"))
+		if err != nil {
+			return output, err
+		}
+		defer failedAddonOut.Close()
+		for failed, reason := range failedAddons {
+			_, err = failedAddonOut.WriteString(fmt.Sprintf("%s: %v\n", failed, reason))
+			if err != nil {
+				return output, err
+			}
+		}
+	}
+
+	// write the diagnostic metadata
+	metaOut, err := os.Create(filepath.Join(output, "meta.txt"))
+	if err != nil {
+		return output, err
+	}
+	defer metaOut.Close()
+	_, err = metaOut.WriteString(meta)
+	if err != nil {
+		return output, err
+	}
+
+	return output, nil
 }
 
 func (c *Cleaner) Cleanup(ctx context.Context) error {


### PR DESCRIPTION
Related to #306. Not sure what @randmonkey had in progress also but I figure there's room for both.

Adds log level support to the Kong Addon, which isn't directly related to this, but I noticed that the dumped Kong logs were at the default info level and thought we'd probably want it also.

Adds `DumpDiagnostics()` functions to Cleaner and Addon types. The Cleaner function takes a context and string and:
- Dumps all resources via kubectl.
- Describes all resources via kubectl.
- Gathers logs from all Pods.
- Runs all enabled Addon `DumpDiagnostics()` functions.
- Writes the outputs to various files in a tmpdir and the input string to meta.txt. meta.txt will usually be the test name, to provide an alternative to logging the directory in the caller and trawling job output to match the dump to its test.
- Returns the tmpdir name.

Addon functions do whatever. This iteration adds a basic diagnostic for the Kong addon, which dumps the root endpoint and `/config` if DB-less.

For example usage, see [this modified test](https://github.com/Kong/kubernetes-ingress-controller/blob/18dadb15d101a172e18c94f282d7250140ebd2e8/test/integration/httproute_test.go#L35-L42) and [this modified workflow](
https://github.com/Kong/kubernetes-ingress-controller/blob/18dadb15d101a172e18c94f282d7250140ebd2e8/.github/workflows/test.yaml#L149-L155). Example CI output can be found at https://github.com/rainest/kubernetes-ingress-controller/actions/runs/2741559860

The CI run was a bit old and was missing some fixes to properly collect Kong data. [ktf-diag-2238065624.tar.gz](https://github.com/Kong/kubernetes-testing-framework/files/9192642/ktf-diag-2238065624.tar.gz) is an example with the current code. Note that this feature requires using the Cleaner throughout a test, since any remaining independent defers will run first and delete resources you care about before running diagnostics, since their defers will be later on in the test.

Future work:
- Add a deck dump to the Kong diagnostic. We absolutely should have this but I wanted to get the general scaffolding approved first, as it's a bit more work than the DB-less dump.
- Automatically parse the silly `\n`-littered YAML string from `/config` and writing YAML rather than not-YAML wrapped in JSON.
- Add some sort of system that allows tests to inject their own diagnostics. For example, in TestHTTPRouteEssentials we may want to add an HTTP response for `GET /httpbin` on the proxy. Including this in the diagnostic only avoids logging within an Eventually and producing a lot of noise. I haven't yet thought of a clean interface to handle this and, unlike the other two, it should be designed separately in another PR. However, if there are improvements to this initial design that will make that easier, we should note them in review here.