### PR TITLE
feature: add job to test connectivity to tcp service

### DIFF
--- a/.github/workflows/build-push-tcptest-image.yaml
+++ b/.github/workflows/build-push-tcptest-image.yaml
@@ -1,0 +1,92 @@
+name: build and push tcptest image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The version to release (e.g. v0.18.0)'
+        required: true
+      latest:
+        description: 'Whether to tag this release latest'
+        required: true
+        default: 'false'
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse semver string
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@v1
+        with:
+          input_string: ${{ github.event.inputs.tag }}
+          version_extractor_regex: 'v(.*)$'
+      - name: Add standard tags
+        id: standard_tags
+        run: |
+          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
+          echo 'type=raw,value=${{ steps.semver_parser.outputs.fullversion }}' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Add major.minor tag
+        if: ${{ steps.semver_parser.outputs.prerelease == '' }}
+        run: |
+          echo 'TAGS_SUPPLEMENTAL<<EOF' >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo 'type=raw,value=${{ steps.semver_parser.outputs.major }}.${{ steps.semver_parser.outputs.minor }}' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Set up QEMU
+        id: set_qemu
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        id: set_buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker layers
+        id: cache_layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        id: login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: kong/kubernetes-testing-framework-tcptest
+          flavor: |
+            latest=${{ github.event.inputs.latest == 'true' }}
+          tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
+      - name: Build binary
+        id: docker_build_binary
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          file: Dockerfile_tcptest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          target: builder
+          platforms: linux/amd64, linux/arm64
+          build-args: |
+            TAG=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            REPO_INFO=https://github.com/${{ github.repository }}.git
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: Dockerfile_tcptest
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          target: distroless
+          platforms: linux/amd64, linux/arm64
+          build-args: |
+            TAG=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            REPO_INFO=https://github.com/${{ github.repository }}.git

--- a/Dockerfile_tcptest
+++ b/Dockerfile_tcptest
@@ -1,0 +1,13 @@
+# Build the tcptest binary
+FROM golang:1.18 as builder
+WORKDIR /workspace
+COPY cmd/ cmd/
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o tcptest -ldflags "-s -w " ./cmd/tcptest
+
+# Build
+FROM gcr.io/distroless/static:nonroot AS distroless
+WORKDIR /
+COPY --from=builder /workspace/tcptest .
+ENTRYPOINT ["/tcptest"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ GOOS ?= "linux"
 GOARCH ?= "amd64"
 NCPU ?= $(shell getconf _NPROCESSORS_ONLN)
 
+IMG_TCPTEST ?= "kong/ktf-tcptest"
+TAG_TCPTEST ?= "latest"
+
 all: build
 
 .PHONY: clean
@@ -50,3 +53,9 @@ test.integration:
 .PHONY: test.e2e
 test.e2e:
 	@GOFLAGS="-tags=e2e_tests" go test -timeout 45m -race -v ./test/e2e/...
+
+image.tcptest:
+	docker buildx build -f ./Dockerfile_tcptest -t $(IMG_TCPTEST):$(TAG_TCPTEST) .
+
+push.tcptest:
+	docker push $(IMG_TCPTEST):$(TAG_TCPTEST)

--- a/cmd/tcptest/main.go
+++ b/cmd/tcptest/main.go
@@ -1,0 +1,44 @@
+package main
+
+// This is the code to build image for running jobs to test TCP connectivity of service.
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+const (
+	DefaultTestTimeout    = 60 * time.Second
+	DefaultConnectTimeout = 3 * time.Second
+)
+
+func main() {
+
+	var address string
+	testTimeout := DefaultTestTimeout
+	connectTimeout := DefaultConnectTimeout
+
+	flag.StringVar(&address, "test-address", "127.0.0.1:80", "test connectivity of this address")
+	flag.DurationVar(&testTimeout, "test-timeout", DefaultTestTimeout, "timeout before successfully connected to test address")
+	flag.DurationVar(&connectTimeout, "connect-timeout", DefaultConnectTimeout, "timeout for a single connect")
+	flag.Parse()
+
+	timeoutTimer := time.NewTimer(testTimeout)
+	for {
+		select {
+		case <-timeoutTimer.C:
+			fmt.Printf("ERROR: timed out to connect to %s\n", address)
+			os.Exit(1)
+		default:
+			_, err := net.DialTimeout("tcp", address, connectTimeout)
+			if err == nil {
+				fmt.Printf("INFO: succeeded to connect to %s\n", address)
+				return
+			}
+			// TODO: directly exit with non-0 code for some errors that can fail without retry, e.g: bad address
+		}
+	}
+}

--- a/pkg/utils/kubernetes/networking/services.go
+++ b/pkg/utils/kubernetes/networking/services.go
@@ -3,8 +3,13 @@ package networking
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -44,4 +49,99 @@ func WaitForServiceLoadBalancerAddress(ctx context.Context, c *kubernetes.Client
 			}
 		}
 	}
+}
+
+// WaitForTCPAddressConnected waits for a tcp address to be connected.
+// if the TCP address is successfully connected from the pod inside cluster, it returns nil
+// returns error if the address could not be connected with TCP within duration `timeout`.
+func WaitForTCPAddressConnected(ctx context.Context, c *kubernetes.Clientset, jobNamespace string, address string, timeout time.Duration) error {
+	// TODO: push the image to kong repo and put the tcpTestImage to a global var/const
+	var tcpTestImage = "richardyi/ktf-tcptest:0.0" // should FIX this, currently my personal repo, but available.
+
+	id := uuid.NewString()
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tcp-test-" + id,
+			Labels: map[string]string{
+				"app":  "tcp-test",
+				"task": id,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:  "tcp-test",
+							Image: tcpTestImage,
+							Args: []string{
+								"-test-address=" + address,
+								"-test-timeout=" + timeout.String(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// TODO: use another namespace.
+	job, err := c.BatchV1().Jobs(jobNamespace).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		// added nolint here because we do not care about error in deleting the job, only the job status.
+		c.BatchV1().Jobs(jobNamespace).Delete(ctx, job.Name, metav1.DeleteOptions{}) // nolint:errcheck
+	}()
+
+	jobWatch, err := c.BatchV1().Jobs(job.Namespace).Watch(ctx, metav1.ListOptions{
+		LabelSelector: "task=" + id,
+	})
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context deadline exceeded")
+		case event := <-jobWatch.ResultChan():
+			if event.Type == watch.Modified {
+				obj := event.Object
+				observedJob, ok := obj.(*batchv1.Job)
+				if !ok {
+					return fmt.Errorf("wrong type of object in watch: %T", obj)
+				}
+				if observedJob.Name != job.Name {
+					continue
+				}
+				if observedJob.Status.Succeeded > 0 {
+					return nil
+				}
+				if observedJob.Status.Failed > 0 {
+					return fmt.Errorf("job failed")
+				}
+			}
+		}
+	}
+}
+
+// WaitForServicePortConnected wait for a port of a service be able to be connected with TCP.
+// if useDNS is true, it tries the address name.namespace.svc:port.
+// else it uses clusterIP:port.
+func WaitForServicePortConnected(ctx context.Context, c *kubernetes.Clientset, namespace string, name string, port int, useDNS bool, timeout time.Duration) error {
+	service, err := c.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if useDNS {
+		address := fmt.Sprintf("%s.%s.svc:%d", name, namespace, port)
+		return WaitForTCPAddressConnected(ctx, c, namespace, address, timeout)
+	}
+
+	clusterIP := service.Spec.ClusterIP
+	address := fmt.Sprintf("%s:%d", clusterIP, port)
+	return WaitForTCPAddressConnected(ctx, c, namespace, address, timeout)
 }


### PR DESCRIPTION
Try to add a job to test connectivity to a TCP service inside a k8s cluster to solve #331.
DONE in this PR:
- create a image retries to connect to a TCP address and push it to Kong repo
- KTF provide a method to wait for a TCP address to be connected by the image above

TODO:
- support more parameters (connect timeout/retry interval or retry times)
- discuss about other kinds of "tests", http/https/tls/udp ?