### PR TITLE
fix: use correct command for describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,22 @@
 ## v0.19.0 
 
 ### Added
+
 - Added feature to support waiting for a port of a service to be connective
   by TCP.
   [#338](https://github.com/Kong/kubernetes-testing-framework/pull/338)
 
 ### Improved
+
 - Increased retry times to increase the timeout to wait for kuma webhook
   to be ready to serve.
   [#341](https://github.com/Kong/kubernetes-testing-framework/pull/341)
   [#342](https://github.com/Kong/kubernetes-testing-framework/pull/342)
+
+### Fixed
+
+- Diagnostics runs the correct command for `kubectl describe`.
+  [#343](https://github.com/Kong/kubernetes-testing-framework/pull/343)
 
 ## v0.18.0
 

--- a/pkg/clusters/cleanup.go
+++ b/pkg/clusters/cleanup.go
@@ -83,7 +83,7 @@ func (c *Cleaner) DumpDiagnostics(ctx context.Context, meta string) (string, err
 	if err != nil {
 		return output, err
 	}
-	cmd = exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig.Name(), "get", "all", "--all-namespaces", "-o", "yaml") //nolint:gosec
+	cmd = exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig.Name(), "describe", "all", "--all-namespaces") //nolint:gosec
 	cmd.Stdout = describeAllOut
 	if err := cmd.Run(); err != nil {
 		return output, err


### PR DESCRIPTION
Didn't change the command after copy pasting originally, whoops.