### PR TITLE
feat: allow service type selection for kong proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## v0.19.0 
+## Unreleased
+
+### Added
+
+- Added the ability to select the `Service` type for the proxy when using the
+  Kong addon via the Go library.
+  [#346](https://github.com/Kong/kubernetes-testing-framework/pull/346)
+
+## v0.19.0
 
 ### Added
 

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // -----------------------------------------------------------------------------
@@ -31,6 +32,7 @@ type Builder struct {
 	proxyImageTag                     string
 	proxyPullSecret                   pullSecret
 	proxyLogLevel                     string
+	proxyServiceType                  corev1.ServiceType
 
 	// proxy server enterprise mode configuration options
 	proxyEnterpriseEnabled            bool
@@ -64,6 +66,11 @@ func (b *Builder) Build() *Addon {
 		b.logger = &logrus.Logger{Out: io.Discard}
 	}
 
+	// LoadBalancer is used by default for historical and convenience reasons.
+	if b.proxyServiceType == "" {
+		b.proxyServiceType = corev1.ServiceTypeLoadBalancer
+	}
+
 	return &Addon{
 		logger: b.logger,
 
@@ -81,6 +88,7 @@ func (b *Builder) Build() *Addon {
 		proxyImageTag:                     b.proxyImageTag,
 		proxyPullSecret:                   b.proxyPullSecret,
 		proxyLogLevel:                     b.proxyLogLevel,
+		proxyServiceType:                  b.proxyServiceType,
 
 		proxyEnterpriseEnabled:            b.proxyEnterpriseEnabled,
 		proxyEnterpriseLicenseJSON:        b.proxyEnterpriseLicenseJSON,
@@ -141,6 +149,13 @@ func (b *Builder) WithControllerImage(repo, tag string) *Builder {
 // WithLogLevel sets the proxy log level
 func (b *Builder) WithLogLevel(level string) *Builder {
 	b.proxyLogLevel = level
+	return b
+}
+
+// WithProxyServiceType indicates which Service type to use for ingress traffic.
+// The default type is LoadBalancer.
+func (b *Builder) WithProxyServiceType(serviceType corev1.ServiceType) *Builder {
+	b.proxyServiceType = serviceType
 	return b
 }
 

--- a/pkg/clusters/addons/kong/vars.go
+++ b/pkg/clusters/addons/kong/vars.go
@@ -48,4 +48,8 @@ const (
 
 	// DefaultTLSServicePort indicates the default open port that will be used for TLS traffic.
 	DefaultTLSServicePort = 8899
+
+	// DefaultProxyNodePort indicates the default NodePort that will be used for
+	// the proxy when applicable.
+	DefaultProxyNodePort = 30080
 )

--- a/pkg/utils/docker/kind.go
+++ b/pkg/utils/docker/kind.go
@@ -9,6 +9,9 @@ import "fmt"
 var (
 	// KindContainerSuffix provides the string suffix that Kind names all cluster containers with.
 	KindContainerSuffix = "-control-plane"
+
+	// DefaultKindNetwork is the name of the default Docker network used for Kind clusters
+	DefaultKindNetwork = "kind"
 )
 
 // -----------------------------------------------------------------------------
@@ -18,4 +21,21 @@ var (
 // GetKindContainerID produces the docker container ID for the given kind cluster by name.
 func GetKindContainerID(clusterName string) string {
 	return fmt.Sprintf("%s%s", clusterName, KindContainerSuffix)
+}
+
+// GetContainerIP retrieves the IPv4 address of a Kind container given the cluster name.
+func GetKindContainerIP(clusterName string) (string, error) {
+	containerID := GetKindContainerID(clusterName)
+
+	containerJSON, err := InspectDockerContainer(containerID)
+	if err != nil {
+		return "", err
+	}
+
+	kindNetwork, ok := containerJSON.NetworkSettings.Networks[DefaultKindNetwork]
+	if !ok {
+		return "", fmt.Errorf("missing docker container network %s", DefaultKindNetwork)
+	}
+
+	return kindNetwork.IPAddress, nil
 }


### PR DESCRIPTION
This was originally made in support of https://github.com/Kong/kubernetes-ingress-controller/issues/2808 but became detached from it because a different testing route was taken. It's still valuable to be able to select the service type however, so I figured might as well add it anyway.