### PR TITLE
Support arbitrary Kong proxy envvars and release 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,22 @@
 
 ## Unreleased
 
+## v0.20.0
+
 ### Added
 
 - Added the ability to select the `Service` type for the proxy when using the
   Kong addon via the Go library.
   [#346](https://github.com/Kong/kubernetes-testing-framework/pull/346)
+- Added `WithProxyEnvVar()` Kong addon builder function, which sets environment
+  variables for the proxy container.
+  [#369](https://github.com/Kong/kubernetes-testing-framework/pull/369)
+
+### Fixed
+
+- Diagnostics now gets all resources, not the reduced set of resources returned
+  by `kubectl get all`.
+  [#362](https://github.com/Kong/kubernetes-testing-framework/pull/362)
 
 ## v0.19.0
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 require github.com/docker/go-connections v0.4.0 // indirect
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/kong/deck v1.14.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/cli-runtime v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPp
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -90,6 +90,7 @@ type Addon struct {
 	proxyPullSecret                   pullSecret
 	proxyLogLevel                     string
 	proxyServiceType                  corev1.ServiceType
+	proxyEnvVars                      map[string]string
 
 	// proxy server enterprise mode configuration options
 	proxyEnterpriseEnabled            bool
@@ -332,6 +333,10 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 
 		// set the enterprise defaults helm installation values
 		a.deployArgs = append(a.deployArgs, enterpriseDefaults()...)
+	}
+
+	for name, value := range a.proxyEnvVars {
+		a.deployArgs = append(a.deployArgs, []string{"--set", fmt.Sprintf("env.%s=%s", name, value)}...)
 	}
 
 	// compile the helm installation values

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -33,6 +33,7 @@ type Builder struct {
 	proxyPullSecret                   pullSecret
 	proxyLogLevel                     string
 	proxyServiceType                  corev1.ServiceType
+	proxyEnvVars                      map[string]string
 
 	// proxy server enterprise mode configuration options
 	proxyEnterpriseEnabled            bool
@@ -44,9 +45,10 @@ type Builder struct {
 // Kong Addon objects which can be deployed to cluster.Clusters
 func NewBuilder() *Builder {
 	builder := &Builder{
-		namespace:  DefaultNamespace,
-		name:       DefaultDeploymentName,
-		deployArgs: []string{},
+		namespace:    DefaultNamespace,
+		name:         DefaultDeploymentName,
+		deployArgs:   []string{},
+		proxyEnvVars: make(map[string]string),
 	}
 	return builder.WithDBLess()
 }
@@ -89,6 +91,7 @@ func (b *Builder) Build() *Addon {
 		proxyPullSecret:                   b.proxyPullSecret,
 		proxyLogLevel:                     b.proxyLogLevel,
 		proxyServiceType:                  b.proxyServiceType,
+		proxyEnvVars:                      b.proxyEnvVars,
 
 		proxyEnterpriseEnabled:            b.proxyEnterpriseEnabled,
 		proxyEnterpriseLicenseJSON:        b.proxyEnterpriseLicenseJSON,
@@ -156,6 +159,13 @@ func (b *Builder) WithLogLevel(level string) *Builder {
 // The default type is LoadBalancer.
 func (b *Builder) WithProxyServiceType(serviceType corev1.ServiceType) *Builder {
 	b.proxyServiceType = serviceType
+	return b
+}
+
+// WithProxyEnvVar sets an arbitrary proxy/Kong container environment variable to a string value. The name must be
+// the lowercase kong.conf style with no KONG_ prefix.
+func (b *Builder) WithProxyEnvVar(name, value string) *Builder {
+	b.proxyEnvVars[name] = value
 	return b
 }
 

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/sethvargo/go-password/password"
 	"github.com/stretchr/testify/require"
 
@@ -41,6 +42,8 @@ func TestKongEnterprisePostgres(t *testing.T) {
 		WithProxyEnterpriseSuperAdminPassword(adminPassword).
 		Build()
 	builder := environment.NewBuilder().WithAddons(kongAddon, metallbAddon)
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)

--- a/test/integration/istio_test.go
+++ b/test/integration/istio_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,13 @@ func TestIstioAddonDeployment(t *testing.T) {
 		WithJaeger().
 		WithKiali().
 		Build()
-	env, err := environments.NewBuilder().WithAddons(metallbAddon, istioAddon).Build(ctx)
+
+	builder := environments.NewBuilder().WithAddons(metallbAddon, istioAddon)
+
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
+
+	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
 	t.Log("waiting for the environment to be ready")

--- a/test/integration/kind_cluster_test.go
+++ b/test/integration/kind_cluster_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -24,6 +25,9 @@ func TestKindClusterBasics(t *testing.T) {
 
 	t.Log("configuring the testing environment")
 	builder := environment.NewBuilder()
+
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.WithAddons(metallb.New(), kong.New()).Build(ctx)
@@ -90,6 +94,9 @@ func TestKindClusterProxyOnly(t *testing.T) {
 
 	t.Log("configuring the testing environment")
 	builder := environment.NewBuilder()
+
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster with the KIC controller disabled")
 	env, err := builder.WithAddons(metallb.New(), kong.NewBuilder().WithControllerDisabled().Build()).Build(ctx)

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -147,6 +148,8 @@ func TestKongAddonDiagnostics(t *testing.T) {
 	t.Log("configuring the testing environment")
 	metallb := metallbaddon.New()
 	builder := environment.NewBuilder().WithAddons(kong, metallb)
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)
@@ -207,6 +210,8 @@ func TestKongAddonDiagnosticsPostgres(t *testing.T) {
 	t.Log("configuring the testing environment")
 	metallb := metallbaddon.New()
 	builder := environment.NewBuilder().WithAddons(kong, metallb)
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)
@@ -242,6 +247,8 @@ func TestKongWithNodePort(t *testing.T) {
 	metallbAddon := metallbaddon.New()
 	kongAddon := kongaddon.NewBuilder().WithProxyServiceType(corev1.ServiceTypeNodePort).Build()
 	builder := environment.NewBuilder().WithAddons(kongAddon, metallbAddon)
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)

--- a/test/integration/metallb_test.go
+++ b/test/integration/metallb_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,6 +26,8 @@ func TestEnvironmentWithMetallb(t *testing.T) {
 	metallb := metallbaddon.New()
 	kong := kongaddon.New()
 	builder := environment.NewBuilder().WithAddons(kong, metallb)
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)

--- a/test/integration/postgres_test.go
+++ b/test/integration/postgres_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 
 	kongaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
@@ -22,6 +23,8 @@ func TestKongWithPostgresDBMode(t *testing.T) {
 	metallb := metallbaddon.New()
 	kong := kongaddon.NewBuilder().WithPostgreSQL().Build()
 	builder := environment.NewBuilder().WithAddons(kong, metallb)
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)

--- a/test/integration/registry_test.go
+++ b/test/integration/registry_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,8 @@ func TestEnvironmentWithRegistryAddon(t *testing.T) {
 		certmanager.New(),
 		registryAddon,
 	)
+	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
+	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)


### PR DESCRIPTION
Add a new WithProxyEnvVar function to the Kong addon builder. This takes a name and value and adds an environment variable with that name and value to the Kong container.

Update changelog in preparation for a 0.20 release.

Temporarily pin the Kubernetes version to mitigate #364 