### PR TITLE
chore: bump metallb to v0.13.5 to support k8s v1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 require github.com/docker/go-connections v0.4.0 // indirect
 
 require (
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/kong/deck v1.14.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/cli-runtime v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPp
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/sethvargo/go-password/password"
 	"github.com/stretchr/testify/require"
 
@@ -42,8 +41,6 @@ func TestKongEnterprisePostgres(t *testing.T) {
 		WithProxyEnterpriseSuperAdminPassword(adminPassword).
 		Build()
 	builder := environment.NewBuilder().WithAddons(kongAddon, metallbAddon)
-	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
-	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)
@@ -100,7 +97,7 @@ func TestKongEnterprisePostgres(t *testing.T) {
 
 	t.Log("verifying enterprise workspace API functionality")
 	workspaceEnabledProxyURL := adminURL.String() + "/workspaces"
-	var jsonStr = []byte(`{"name": "test-workspace"}`)
+	jsonStr := []byte(`{"name": "test-workspace"}`)
 	req, err = http.NewRequest("POST", workspaceEnabledProxyURL, bytes.NewBuffer(jsonStr))
 	require.NoError(t, err)
 	req.Header.Set("kong-admin-token", adminPassword)

--- a/test/integration/istio_test.go
+++ b/test/integration/istio_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,9 +32,6 @@ func TestIstioAddonDeployment(t *testing.T) {
 		Build()
 
 	builder := environments.NewBuilder().WithAddons(metallbAddon, istioAddon)
-
-	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
-	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -148,8 +148,6 @@ func TestKongAddonDiagnostics(t *testing.T) {
 	t.Log("configuring the testing environment")
 	metallb := metallbaddon.New()
 	builder := environment.NewBuilder().WithAddons(kong, metallb)
-	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
-	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)
@@ -247,8 +245,6 @@ func TestKongWithNodePort(t *testing.T) {
 	metallbAddon := metallbaddon.New()
 	kongAddon := kongaddon.NewBuilder().WithProxyServiceType(corev1.ServiceTypeNodePort).Build()
 	builder := environment.NewBuilder().WithAddons(kongAddon, metallbAddon)
-	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
-	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)

--- a/test/integration/metallb_test.go
+++ b/test/integration/metallb_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -26,8 +25,6 @@ func TestEnvironmentWithMetallb(t *testing.T) {
 	metallb := metallbaddon.New()
 	kong := kongaddon.New()
 	builder := environment.NewBuilder().WithAddons(kong, metallb)
-	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
-	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)

--- a/test/integration/postgres_test.go
+++ b/test/integration/postgres_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 
 	kongaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/kong"
@@ -23,8 +22,6 @@ func TestKongWithPostgresDBMode(t *testing.T) {
 	metallb := metallbaddon.New()
 	kong := kongaddon.NewBuilder().WithPostgreSQL().Build()
 	builder := environment.NewBuilder().WithAddons(kong, metallb)
-	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
-	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)

--- a/test/integration/registry_test.go
+++ b/test/integration/registry_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,8 +32,6 @@ func TestEnvironmentWithRegistryAddon(t *testing.T) {
 		certmanager.New(),
 		registryAddon,
 	)
-	// TODO https://github.com/Kong/kubernetes-testing-framework/issues/364 remove once metallb behaves again
-	builder = builder.WithKubernetesVersion(semver.Version{Major: 1, Minor: 24, Patch: 4})
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)


### PR DESCRIPTION
This PR bumps the metallb manifest to use [v0.13.5](https://github.com/metallb/metallb/releases/tag/v0.13.5) which drops usage of pod security policy (which is unavailable in k8s v1.25+).

Initially I wanted to avoid using the [`IPAddressPool`](https://metallb.universe.tf/configuration/#defining-the-ips-to-assign-to-the-load-balancer-services) but on the kind cluster that I performed the testing the services would never get the IPs.

Fixes #364

Probably we should use a different mechanism of deployment, not using `kubectl` (like mentioned  in the comment in metallb addon's source code).