### PR TITLE
fix: delete resources if existed in metallb addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- Delete `IPAddressPool` and `L2Advertisement` resources if the resource
+  exists before creating in metallb addon.
+  [#390](https://github.com/Kong/kubernetes-testing-framework/pull/390)
+
+
 ## v0.21.0
 
 ### Fixed


### PR DESCRIPTION
delete `IPAddressPool` and `L2Advertisement` resource if the resource exists before creating in `metallb` addon. Fixes #381.