### PR TITLE
fix: move error log and release 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.22.1
+
+### Fixed
+
+- Moved metallb error recording inside context switch, to avoid
+  recording the context expiration as the last error.
+
 ## v0.22.0
 
 ### Added 

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -237,9 +237,9 @@ func createIPAddressPool(ctx context.Context, cluster clusters.Cluster, dockerNe
 				err = res.Delete(ctx, addressPoolName, metav1.DeleteOptions{})
 			}
 
-			lastErr = err
 			select {
 			case <-time.After(time.Second):
+				lastErr = err
 				continue
 			case <-ctx.Done():
 				return fmt.Errorf("failed to create metallb.io/v1beta1 IPAddressPool: %w, last error on create: %v", ctx.Err(), lastErr)


### PR DESCRIPTION
metallb IPAddressPool creation failures are currently logging lines like:

```
failed to deploy addon metallb: failed to create metallb.io/v1beta1 IPAddressPool: context deadline exceeded, last error on create: Post "https://127.0.0.1:36091/apis/metallb.io/v1beta1/namespaces/metallb-system/ipaddresspools": context deadline exceeded
```
Code review suggests that since we're assigning lastErr after the creation attempt but before the switch handling the `ctx.Done()` case, where the switch context is the same context we pass to the create request, the last create request fails because the context is done and then wipes out the previous error. That previous error was hopefully more interesting, because it should be whatever prevented the loop from completing before the context expired.

Moving the lastErr update inside the context-not-expired switch case should avoid this and thus log the last not-context expired error. Not tested though since I don't have a quick way to trigger the situation. Please double-check my thinking here.

Release a patch release for this fix.