### PR TITLE
chore: increase the metallb timeout and release 0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.22.2
+
+- Increased the metallb startup timeout.
+
 ## v0.22.1
 
 ### Fixed

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -211,7 +211,7 @@ func createIPAddressPool(ctx context.Context, cluster clusters.Cluster, dockerNe
 
 	res := dynamicClient.Resource(ipapResource).Namespace(DefaultNamespace)
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*3) //nolint:gomnd
 	defer cancel()
 
 	var lastErr error


### PR DESCRIPTION
Increase this. E2E failed almost always once per instance with the old timeout. It failed in one out of ~ten with 2 minutes. May as well let it run.

Alternative is that we just disable the webhook, we don't really need it.

If you merge, please initiate the release job. Auto-merge is off, I'll do it it's still around by morning. 