### PR TITLE
fix: ignore metallb admission

### DIFF
--- a/pkg/clusters/utils.go
+++ b/pkg/clusters/utils.go
@@ -210,7 +210,7 @@ func CleanupGeneratedResources(ctx context.Context, cluster Cluster, creatorID s
 func KustomizeDeployForCluster(ctx context.Context, cluster Cluster, kustomizeURL string) error {
 	// generate the kustomize YAML
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, "kubectl", "kustomize", kustomizeURL)
+	cmd := exec.CommandContext(ctx, "kubectl", "-v9", "kustomize", kustomizeURL)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
@@ -225,7 +225,7 @@ func KustomizeDeployForCluster(ctx context.Context, cluster Cluster, kustomizeUR
 func KustomizeDeleteForCluster(ctx context.Context, cluster Cluster, kustomizeURL string) error {
 	// generate the kustomize YAML
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, "kubectl", "kustomize", kustomizeURL)
+	cmd := exec.CommandContext(ctx, "kubectl", "-v9", "kustomize", kustomizeURL)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {

--- a/pkg/utils/kubernetes/kubectl/kustomize.go
+++ b/pkg/utils/kubernetes/kubectl/kustomize.go
@@ -1,0 +1,58 @@
+package kubectl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+// GetKustomizedManifest takes a kustomization and any number of manifest readers. It adds the manifests to the
+// kustomization's resources and returns a reader with the rendered kustomization.
+func GetKustomizedManifest(kustomization types.Kustomization, manifests ...io.Reader) (io.Reader, error) {
+	workDir, err := os.MkdirTemp("", "ktf.")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(workDir)
+	for i, manifest := range manifests {
+		orig, err := io.ReadAll(manifest)
+		if err != nil {
+			return nil, err
+		}
+		err = os.WriteFile(filepath.Join(workDir, fmt.Sprintf("base_%d.yaml", i)), orig, 0o600) //nolint:gomnd
+		if err != nil {
+			return nil, err
+		}
+		kustomization.Resources = append(kustomization.Bases, fmt.Sprintf("base_%d.yaml", i))
+	}
+	marshalled, err := yaml.Marshal(kustomization)
+	if err != nil {
+		return nil, err
+	}
+	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), marshalled, 0o600) //nolint:gomnd
+	if err != nil {
+		return nil, err
+	}
+	kustomized, err := runKustomize(workDir)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(kustomized), nil
+}
+
+// runKustomize runs kustomize on a path and returns the YAML output.
+func runKustomize(path string) ([]byte, error) {
+	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
+	m, err := k.Run(filesys.MakeFsOnDisk(), path)
+	if err != nil {
+		return []byte{}, err
+	}
+	return m.AsYaml()
+}

--- a/pkg/utils/kubernetes/kubectl/kustomize.go
+++ b/pkg/utils/kubernetes/kubectl/kustomize.go
@@ -26,11 +26,11 @@ func GetKustomizedManifest(kustomization types.Kustomization, manifests ...io.Re
 		if err != nil {
 			return nil, err
 		}
-		err = os.WriteFile(filepath.Join(workDir, fmt.Sprintf("base_%d.yaml", i)), orig, 0o600) //nolint:gomnd
+		err = os.WriteFile(filepath.Join(workDir, fmt.Sprintf("resource_%d.yaml", i)), orig, 0o600) //nolint:gomnd
 		if err != nil {
 			return nil, err
 		}
-		kustomization.Resources = append(kustomization.Bases, fmt.Sprintf("base_%d.yaml", i))
+		kustomization.Resources = append(kustomization.Resources, fmt.Sprintf("resource_%d.yaml", i))
 	}
 	marshalled, err := yaml.Marshal(kustomization)
 	if err != nil {


### PR DESCRIPTION
Set the metallb admission controller to ignore. Our IPAddressPools and L2Advertisements are static and work. The admission controller has a habit of not coming online and blocking the deploy. Ignoring its failures avoids this.

Add a kustomize utility and refactor the metallb deploy to use it.

The kustomize utility is generic enough to go into KTF. The specific patches and Kustomization structs will be provided by individual tests (or, in KTF's case, plugins). This is adapted from the code originally introduced in https://github.com/Kong/kubernetes-ingress-controller/pull/2995 and would replace it in KIC once released. It differs in that it instead takes a variadic manifest argument and appends these to the resources, rather than replacing the resources entirely with a single manifest resource. This allows for additional resources as well as URLs (URLs you can just stick in the Kustomization directly; they don't need a helper to write the local file and inject a generated filename).