### PR TITLE
fix: use wider IP range for metallb ipaddresspool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.22.3
+
+- Increased the metallb `IPAddressPool` IP range.
+
 ## v0.22.2
 
 - Increased the metallb startup timeout.

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -138,7 +138,7 @@ func (a *addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (
 // -----------------------------------------------------------------------------
 
 var (
-	defaultStartIP = net.ParseIP("0.0.0.240")
+	defaultStartIP = net.ParseIP("0.0.0.100")
 	defaultEndIP   = net.ParseIP("0.0.0.250")
 	metalManifest  = "https://raw.githubusercontent.com/metallb/metallb/v0.13.5/config/manifests/metallb-native.yaml"
 	secretKeyLen   = 128

--- a/pkg/clusters/addons/metallb/metallb_test.go
+++ b/pkg/clusters/addons/metallb/metallb_test.go
@@ -15,7 +15,7 @@ func TestHelperFunctions(t *testing.T) {
 		Mask: net.IPv4Mask(0, 0, 0, 255),
 	}
 	ip1, ip2 := getIPRangeForMetallb(network)
-	assert.Equal(t, ip1.String(), net.IPv4(192, 168, 1, 240).String())
+	assert.Equal(t, ip1.String(), net.IPv4(192, 168, 1, 100).String())
 	assert.Equal(t, ip2.String(), net.IPv4(192, 168, 1, 250).String())
-	assert.Equal(t, networking.GetIPRangeStr(ip1, ip2), "192.168.1.240-192.168.1.250")
+	assert.Equal(t, networking.GetIPRangeStr(ip1, ip2), "192.168.1.100-192.168.1.250")
 }


### PR DESCRIPTION
For some test environments, 10 IP addresses might not be enough resulting in situations where the IPs for some services are perpetually pending, causing tests to time out and fail.

This PR should help to some extent by extending the range from 10 to 150 IPs.

This also adds a release note for v0.22.3 to release it after this gets merged.