### PR TITLE
Add environment support for provided cluster builders

### DIFF
--- a/pkg/clusters/cluster.go
+++ b/pkg/clusters/cluster.go
@@ -47,3 +47,7 @@ type Cluster interface {
 	// DeleteAddon removes an existing cluster Addon.
 	DeleteAddon(ctx context.Context, addon Addon) error
 }
+
+type Builder interface {
+	Build(ctx context.Context) (Cluster, error)
+}

--- a/pkg/clusters/types/kind/builder.go
+++ b/pkg/clusters/types/kind/builder.go
@@ -60,7 +60,7 @@ func (b *Builder) WithCalicoCNI() *Builder {
 }
 
 // Build creates and configures clients for a Kind-based Kubernetes clusters.Cluster.
-func (b *Builder) Build(ctx context.Context) (*Cluster, error) {
+func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 	deployArgs := make([]string, 0)
 	if b.clusterVersion != nil {
 		deployArgs = append(deployArgs, "--image", "kindest/node:v"+b.clusterVersion.String())

--- a/pkg/clusters/types/kind/cluster.go
+++ b/pkg/clusters/types/kind/cluster.go
@@ -42,7 +42,8 @@ type Cluster struct {
 
 // New provides a new clusters.Cluster backed by a Kind based Kubernetes Cluster.
 func New(ctx context.Context) (*Cluster, error) {
-	return NewBuilder().Build(ctx)
+	cluster, err := NewBuilder().Build(ctx)
+	return cluster.(*Cluster), err
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Add environment functionality to build an environment given a cluster builder, in addition to the current options of a pre-built cluster or an opinionated default KIND cluster builder.

The environment design doesn't seem to offer a good means of configuring functionality not supported across all cluster types. The image load addon is a prime example, where the current implementation is closely tied to KIND functionality and there is no GKE implementation (though there could be). As the cluster builders are all type-specific, they provide the most obvious injection point for type-specific functionality.

Injecting these into an environment prior to the environment build does not require significant changes to the environment builder, since it already needed to build the cluster when using the default cluster.

Special note or whatever:

The existin kind Builder `Build()` method [returns a kind.Cluster](https://github.com/Kong/kubernetes-testing-framework/blob/cd3a50b0d3f3f21fac93a0e0470eb32dbfe93c84/pkg/clusters/types/kind/builder.go#L63) and this PR changes it to return a `clusters.Cluster` to support a uniform `Build()` interface. The GKE Builder [already did this](https://github.com/Kong/kubernetes-testing-framework/blob/cd3a50b0d3f3f21fac93a0e0470eb32dbfe93c84/pkg/clusters/types/gke/builder.go#L64).

The [kind New](https://github.com/Kong/kubernetes-testing-framework/blob/cd3a50b0d3f3f21fac93a0e0470eb32dbfe93c84/pkg/clusters/types/kind/cluster.go#L44) and [GKE New](https://github.com/Kong/kubernetes-testing-framework/blob/cd3a50b0d3f3f21fac93a0e0470eb32dbfe93c84/pkg/clusters/types/gke/cluster.go#L56) functions originally returned their specific cluster type, and still do.

There wasn't an obvious reason for the discrepancy between the builders originally, so this may be worth thinking about if someone can remember one or we think there's a better way to design the signatures overall.