### PR TITLE
chore(ci): use PAT for tagging instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT_GITHUB }}
 
     # --------------------------------------------------------------------------
     # Run Tests


### PR DESCRIPTION
Attempt to address https://github.com/Kong/kubernetes-testing-framework/issues/337

[The github documentation ](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) states that the `GITHUB_TOKEN` should not be used for triggering a new workflow run from github actions itself. Using `GITHUB_TOKEN` prevents other workflows from triggering to avoid recursive workflow runs. It stopped working for us some time ago. This is an attempt to make it working again by changing the token used during the checkout to PAT.