### PR TITLE
tests: use Github Actions matrix for integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,10 +14,6 @@ jobs:
     environment: "integration-tests"
     runs-on: ubuntu-latest
     steps:
-    - uses: Kong/kong-license@master
-      id: license
-      with:
-        password: ${{ secrets.PULP_PASSWORD }}
 
     - name: setup golang
       uses: actions/setup-go@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,14 +3,14 @@ name: tests
 on:
   pull_request:
     branches:
-      - 'main'
+    - 'main'
   push:
     branches:
-      - 'main'
+    - 'main'
   workflow_dispatch: {}
 
 jobs:
-  tests-and-coverage:
+  unit-tests:
     environment: "integration-tests"
     runs-on: ubuntu-latest
     steps:
@@ -40,14 +40,70 @@ jobs:
     - name: run unit tests
       run: make test.unit
 
-    - name: run integration tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+        files: unit.coverage.out
+        verbose: true
+
+  setup-integration-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      test_names: ${{ steps.set_test_names.outputs.test_names }}
+    steps:
+    - uses: actions/checkout@v3
+    - id: set_test_names
+      name: Set test names
+      working-directory: test/integration/
+      # grep magic described in https://unix.stackexchange.com/a/13472
+      # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
+      run: |
+        echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+    - name: Print test names
+      run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
+
+  integration-tests:
+    needs: setup-integration-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.setup-integration-tests.outputs.test_names) }}
+    environment: "integration-tests"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: Kong/kong-license@master
+      id: license
+      with:
+        password: ${{ secrets.PULP_PASSWORD }}
+
+    - name: setup golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.19'
+
+    - name: cache go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: run integration test ${{ matrix.test }}
       run: make test.integration
       env:
         KTF_TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         KTF_TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-        NCPU: 2 # it was found that github actions (specifically) did not seem to perform well when spawning
-                # multiple kind clusters within a single job so this is hardcoded to 2 to ensure a limit of 2 clusters at any one point.
+        TEST_RUN: ${{ matrix.test }}
+        NCPU: 1
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
@@ -56,3 +112,10 @@ jobs:
         fail_ci_if_error: true
         files: unit.coverage.out,integration.coverage.out
         verbose: true
+
+  integration-tests-passed:
+    needs: integration-tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: integrations tests pased
+      run: echo all integrations tests passed

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   unit-tests:
-    environment: "integration-tests"
     runs-on: ubuntu-latest
     steps:
 
@@ -49,7 +48,9 @@ jobs:
     outputs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
     steps:
+
     - uses: actions/checkout@v3
+
     - id: set_test_names
       name: Set test names
       working-directory: test/integration/
@@ -57,22 +58,38 @@ jobs:
       # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
       run: |
         echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+
     - name: Print test names
       run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 
+  setup-kong-license:
+    runs-on: ubuntu-latest
+    environment: "integration-tests"
+    outputs:
+      license_encrypted: ${{ steps.license.outputs.encrypted }}
+    steps:
+
+    - uses: Kong/kong-license@master
+      with:
+        password: ${{ secrets.PULP_PASSWORD }}
+    - name: set encrypted license as output
+      id: license
+      run: |
+        echo "encrypted=$(gpg --symmetric --batch --passphrase ${{ secrets.LICENSE_ENCRYPTION_PASSWORD }} --output - <(echo ${KONG_LICENSE_DATA}) | base64 -w0)" >> $GITHUB_OUTPUT
+
   integration-tests:
-    needs: setup-integration-tests
+    needs:
+    - setup-integration-tests
+    - setup-kong-license
     strategy:
       fail-fast: false
       matrix:
         test: ${{ fromJSON(needs.setup-integration-tests.outputs.test_names) }}
-    environment: "integration-tests"
     runs-on: ubuntu-latest
     steps:
-    - uses: Kong/kong-license@master
-      id: license
-      with:
-        password: ${{ secrets.PULP_PASSWORD }}
+
+    - name: set Kong license env
+      run: echo "KONG_LICENSE_DATA=$(gpg --decrypt --quiet --batch --passphrase ${{ secrets.LICENSE_ENCRYPTION_PASSWORD }} --output - <(echo ${{ needs.setup-kong-license.outputs.license_encrypted }} | base64 --decode ))" >> $GITHUB_ENV
 
     - name: setup golang
       uses: actions/setup-go@v3
@@ -97,7 +114,7 @@ jobs:
       env:
         KTF_TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         KTF_TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
-        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        KONG_LICENSE_DATA: ${{ env.KONG_LICENSE_DATA }}
         TEST_RUN: ${{ matrix.test }}
         NCPU: 1
 

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,14 @@ test.unit:
 		-coverprofile=unit.coverage.out \
 		./pkg/...
 
+TEST_RUN ?= ""
+
 .PHONY: test.integration
 test.integration:
 	@GOFLAGS="-tags=integration_tests" go test \
 		-parallel $(NCPU) \
 		-timeout 45m \
+		-run $(TEST_RUN) \
 		-race \
 		-v \
 		-covermode=atomic \

--- a/test/integration/calico_test.go
+++ b/test/integration/calico_test.go
@@ -151,5 +151,4 @@ func generateNetPol(app string, allowCIDR string) *netv1.NetworkPolicy {
 			}},
 		},
 	}
-
 }


### PR DESCRIPTION
This PR makes it so that ktf integration tests are using a matrix on CI now in such a way that each test runs in it's own workflow. This way we don't expect one test disrupting another one or problems with performance (since default, hosted Github runners are generally known of their not so great performance).

Additionally, this PR adds `integration-tests-passed` job, which has been made required from now on. This makes this setup "scalable" in a way such that when new integration tests are added no actions have to be done in order to make the CI happy.

This also shuffles around the environments to prevent spam in Github conversation view: where not needed the `environment: "integration-tests"` setting has been removed and an additional `setup-kong-license` job has been added to pull the license in 1 place.

Last but not least, this passes the kong license as an encrypted output between `setup-kong-license` and `integration-tests` so that it doesn't get blocked by Github on suspicion of passing secrets/masked variables between actions. The implemented solution was based on https://nitratine.net/blog/post/how-to-pass-secrets-between-runners-in-github-actions/