### PR TITLE
chore: bump metallb to v0.13.7

### DIFF
--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -144,7 +144,7 @@ func (a *addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (
 var (
 	defaultStartIP = net.ParseIP("0.0.0.100")
 	defaultEndIP   = net.ParseIP("0.0.0.250")
-	metalManifest  = "https://github.com/metallb/metallb/config/native?ref=v0.13.6"
+	metalManifest  = "https://github.com/metallb/metallb/config/native?ref=v0.13.7"
 	secretKeyLen   = 128
 )
 


### PR DESCRIPTION
Bump to https://metallb.universe.tf/release-notes/#version-0-13-7