### PR TITLE
chore: update linter settings

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,12 +3,12 @@ name: lint
 on:
   pull_request:
     branches:
-      - '*'
+    - '*'
   push:
     branches:
-      - 'main'
+    - 'main'
     tags:
-      - '*'
+    - '*'
   workflow_dispatch: {}
 
 jobs:
@@ -27,5 +27,3 @@ jobs:
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3.3.0
-      with:
-        version: v1.48.0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - deadcode
   - depguard
   - dogsled
   - durationcheck
@@ -16,6 +15,7 @@ linters:
   - goimports
   - gomnd
   - gosec
+  - gci
   - gosimple
   - govet
   - importas
@@ -27,9 +27,18 @@ linters:
   - predeclared
   - revive
   - staticcheck
-  - structcheck
   - typecheck
   - unconvert
   - unparam
-  - varcheck
+  - unused
   - wastedassign
+
+linters-settings:
+  gci:
+    sections:
+    - standard
+    - default
+    - prefix(github.com/kong/kubernetes-testing-framework)
+
+issues:
+  fix: true

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install:
 
 .PHONY: lint
 lint:
-	@golangci-lint run ./...
+	@golangci-lint run -v ./...
 
 .PHONY: test
 test: test.unit

--- a/internal/utils/cluster_init.go
+++ b/internal/utils/cluster_init.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 )
 
 const (

--- a/pkg/clusters/addons/httpbin/addon.go
+++ b/pkg/clusters/addons/httpbin/addon.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/internal/utils"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"

--- a/pkg/clusters/types/kind/cluster.go
+++ b/pkg/clusters/types/kind/cluster.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/blang/semver/v4"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 )
 

--- a/pkg/clusters/utils.go
+++ b/pkg/clusters/utils.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	netv1 "k8s.io/api/networking/v1"
@@ -18,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
 // -----------------------------------------------------------------------------

--- a/pkg/utils/kong/fake_admin_api_test.go
+++ b/pkg/utils/kong/fake_admin_api_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kong/go-kong/kong"
 	kongt "github.com/kong/kubernetes-testing-framework/pkg/utils/kong"
 )
 


### PR DESCRIPTION
This PR:

- unpins golangci-lint version from [lint workflow](https://github.com/Kong/kubernetes-testing-framework/blob/3dabf4568c7b58b49807035a11f042c52299aeb9/.github/workflows/lint.yaml#L28-L29)
- removes deprecated linters from `golangci-lint.yaml` config
- adds config for `gci`
- fixes linter errors