### PR TITLE
fix(kong addon): use postgresql.auth.username and postgresql.auth.database

### DIFF
--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -257,8 +257,8 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 		a.deployArgs = append(a.deployArgs, []string{
 			"--set", "env.database=postgres",
 			"--set", "postgresql.enabled=true",
-			"--set", "postgresql.postgresqlUsername=kong",
-			"--set", "postgresql.postgresqlDatabase=kong",
+			"--set", "postgresql.auth.username=kong",
+			"--set", "postgresql.auth.database=kong",
 			"--set", "postgresql.service.port=5432",
 		}...)
 	}


### PR DESCRIPTION
Use `postgresql.auth.username` and `postgresql.auth.database` instead of  `postgresql.postgresqlUsername` and `postgresql.postgresqlDatabase` as the later ones were removed from kong chart by https://github.com/Kong/charts/commit/2e89647d86ec7c8fa2a2a1697a325e6679b18d08

Fixes https://github.com/Kong/kubernetes-testing-framework/issues/428