### PR TITLE
chore: update .gitignore with common files that should not be commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ build/*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE directories and files
+.idea/
+.vscode/
+
+# Mac files
+.DS_Store


### PR DESCRIPTION
Adds a few rules to gitignore, that will make the life easier by ignoring ide and mac os related files.