### PR TITLE
chore(kong addon) bump default kong enterprise image from 2.7.0.0 to 3.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Updated default version of Kong Enterprise image from 2.7.0.0 to 3.0.0.0.
 - Changed Kong addon to use udpProxy dict from charts value file to instantiate 
   a udp proxy, instead of creating a udp proxy by kubectl.
 

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -47,7 +47,7 @@ const (
 	DefaultEnterpriseImageRepo = "kong/kong-gateway"
 
 	// DefaultEnterpriseImageTag latest kong enterprise image tag
-	DefaultEnterpriseImageTag = "2.7.0.0-alpine"
+	DefaultEnterpriseImageTag = "3.0.0.0-alpine"
 
 	// DefaultEnterpriseLicenseSecretName is the name that will be used by default for the
 	// Kubernetes secret containing the Kong enterprise license that will be


### PR DESCRIPTION
bump default kong enterprise image from 2.7.0.0 to 3.0.0.0