### PR TITLE
Revert "chore(kong addon) bump default kong enterprise image from 2.7.0.0 to 3.0.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Updated default version of Kong Enterprise image from 2.7.0.0 to 3.0.0.0.
 - Changed Kong addon to use udpProxy dict from charts value file to instantiate 
   a udp proxy, instead of creating a udp proxy by kubectl.
 

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -47,7 +47,7 @@ const (
 	DefaultEnterpriseImageRepo = "kong/kong-gateway"
 
 	// DefaultEnterpriseImageTag latest kong enterprise image tag
-	DefaultEnterpriseImageTag = "3.0.0.0-alpine"
+	DefaultEnterpriseImageTag = "2.7.0.0-alpine"
 
 	// DefaultEnterpriseLicenseSecretName is the name that will be used by default for the
 	// Kubernetes secret containing the Kong enterprise license that will be


### PR DESCRIPTION
Reverts Kong/kubernetes-testing-framework#432

This brakes the KTF and blocks dependant merges.
Need to investigate why dumping kong enterprise image from `2.7.0.0` to `3.0.0.0` breaks KTF.

The `TestKongEnterprisePostgres` fails on every run.  Logs shows that the version is not enterprise.
```
    enterprise_test.go:90: verifying the admin api version is enterprise
    enterprise_test.go:95: admin output: &{Version:3.0.0.0}
```
```go
	t.Log("verifying the admin api version is enterprise")
	adminOutput := struct {
		Version string `json:"version"`
	}{}
	require.NoError(t, json.Unmarshal(body, &adminOutput))
	t.Logf("admin output: %+v", &adminOutput)
	require.True(t, strings.Contains(adminOutput.Version, "enterprise-edition"))
```

