### PR TITLE
chore: use consistent YAML library

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
   - gofmt
   - goimports
   - gomnd
+  - gomodguard
   - gosec
   - gci
   - gosimple
@@ -39,6 +40,18 @@ linters-settings:
     - standard
     - default
     - prefix(github.com/kong/kubernetes-testing-framework)
+  gomodguard:
+    blocked:
+      modules:
+      - github.com/ghodss/yaml:
+          recommendations:
+          - sigs.k8s.io/yaml
+      - gopkg.in/yaml.v2:
+          recommendations:
+          - sigs.k8s.io/yaml
+      - gopkg.in/yaml.v3:
+          recommendations:
+          - sigs.k8s.io/yaml
 
 issues:
   fix: true

--- a/go.mod
+++ b/go.mod
@@ -35,11 +35,9 @@ require (
 require github.com/docker/go-connections v0.4.0 // indirect
 
 require (
-	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-github/v48 v48.1.0
 	github.com/kong/deck v1.16.1
 	golang.org/x/sync v0.1.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/cli-runtime v0.25.4
 	k8s.io/kubectl v0.25.4
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
@@ -69,6 +67,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -150,6 +149,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.25.4 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -19,8 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/kustomize/api/types"
 	kustomize "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"

--- a/pkg/clusters/types/kind/utils.go
+++ b/pkg/clusters/types/kind/utils.go
@@ -9,11 +9,11 @@ import (
 	"os/exec"
 	"sync"
 
-	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 )

--- a/pkg/utils/kubernetes/kubectl/kustomize.go
+++ b/pkg/utils/kubernetes/kubectl/kustomize.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/yaml"
 )
 
 // GetKustomizedManifest takes a kustomization and any number of manifest readers. It adds the manifests to the


### PR DESCRIPTION
Use `sigs.k8s.io/yaml` as the only YAML library.

See also: https://github.com/Kong/deck/pull/800 and https://github.com/Kong/go-kong/pull/239