### PR TITLE
fix(tests): add GITHUB_TOKEN to tests so that they can authenticate against Github API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,6 +98,7 @@ jobs:
     - name: run integration test ${{ matrix.test }}
       run: make test.integration
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KTF_TEST_KONG_PULL_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         KTF_TEST_KONG_PULL_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}


### PR DESCRIPTION
Similar to https://github.com/Kong/kubernetes-ingress-controller/pull/3272, add `GITHUB_TOKEN` to prevent situations like these:

https://github.com/Kong/kubernetes-testing-framework/actions/runs/3766614268/jobs/6403306526#step:6:46

```
failed to deploy addon istio: couldn't fetch latest istio/istio release: GET https://api.github.com/repos/istio/istio/releases/latest: 403 API rate limit exceeded for 172.177.255.2. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 10m42s]
```