### PR TITLE
feat(gke): allow creating subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.25.0
+## Unreleased 
 
 - GKE cluster builder allows creating a subnet for the cluster instead of using 
   a default one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.25.0
+
+- GKE cluster builder allows creating a subnet for the cluster instead of using 
+  a default one.
+  [#490](https://github.com/Kong/kubernetes-testing-framework/pull/490)
 
 ## v0.24.1
 

--- a/pkg/clusters/types/gke/builder.go
+++ b/pkg/clusters/types/gke/builder.go
@@ -214,8 +214,8 @@ func (b *Builder) createCluster(ctx context.Context, req *containerpb.CreateClus
 	return nil
 }
 
-func (b *Builder) createClusterUsingCLI(ctx context.Context, req *containerpb.CreateClusterRequest, createdByID string, authToken string) error {
-	tokenFile, err := os.CreateTemp("/tmp", "gcloud-token-")
+func (b *Builder) createClusterUsingCLI(ctx context.Context, req *containerpb.CreateClusterRequest, createdByID, authToken string) error {
+	tokenFile, err := os.CreateTemp("", "gcloud-token-")
 	if err != nil {
 		return fmt.Errorf("failed to create a temporary file for gcloud token: %w", err)
 	}
@@ -226,6 +226,7 @@ func (b *Builder) createClusterUsingCLI(ctx context.Context, req *containerpb.Cr
 		return fmt.Errorf("failed to write a token to the temporary file: %w", err)
 	}
 
+	//nolint:gosec
 	cmd := exec.CommandContext(ctx, "gcloud", "container", "clusters", "create", req.Cluster.Name,
 		`--access-token-file`, tokenFile.Name(),
 		`--project`, b.project,

--- a/pkg/clusters/types/gke/builder.go
+++ b/pkg/clusters/types/gke/builder.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
-	containerpb "cloud.google.com/go/container/apiv1/containerpb"
+	container "cloud.google.com/go/container/apiv1"
+	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 
@@ -22,6 +26,7 @@ type Builder struct {
 	project, location string
 	jsonCreds         []byte
 
+	createSubnet   bool
 	addons         clusters.Addons
 	clusterVersion *semver.Version
 	majorMinor     string
@@ -60,6 +65,11 @@ func (b *Builder) WithClusterMinorVersion(major, minor uint64) *Builder {
 	return b
 }
 
+func (b *Builder) WithCreateSubnet(create bool) *Builder {
+	b.createSubnet = create
+	return b
+}
+
 // Build creates and configures clients for a GKE-based Kubernetes clusters.Cluster.
 func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 	// validate the credential contents by finding the IAM service account
@@ -75,6 +85,7 @@ func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 	if createdByID == "" {
 		return nil, fmt.Errorf("provided credentials were invalid: 'client_id' can not be an empty string")
 	}
+	createdByID = sanitizeCreatedByID(createdByID)
 
 	// generate an auth token and management client
 	mgrc, authToken, err := clientAuthFromCreds(ctx, b.jsonCreds)
@@ -94,7 +105,7 @@ func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 		},
 		ResourceLabels: map[string]string{GKECreateLabel: createdByID},
 	}
-	req := containerpb.CreateClusterRequest{Parent: parent, Cluster: &pbcluster}
+	req := &containerpb.CreateClusterRequest{Parent: parent, Cluster: &pbcluster}
 
 	// use any provided custom cluster version
 	if b.clusterVersion != nil && b.majorMinor != "" {
@@ -115,9 +126,7 @@ func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 		pbcluster.InitialClusterVersion = v.String()
 	}
 
-	// create the GKE cluster asynchronously
-	_, err = mgrc.CreateCluster(ctx, &req)
-	if err != nil {
+	if err := b.createCluster(ctx, req, mgrc, createdByID); err != nil {
 		return nil, err
 	}
 
@@ -175,4 +184,56 @@ func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 	}
 
 	return cluster, nil
+}
+
+// createCluster creates the GKE cluster asynchronously.
+func (b *Builder) createCluster(ctx context.Context, req *containerpb.CreateClusterRequest, mgrc *container.ClusterManagerClient, createdByID string) error {
+	// createSubnet is currently only available via gcloud CLI:
+	// https://github.com/googleapis/google-cloud-go/issues/7219
+	if b.createSubnet {
+		if err := b.createClusterUsingCLI(ctx, req, createdByID); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	_, err := mgrc.CreateCluster(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Builder) createClusterUsingCLI(ctx context.Context, req *containerpb.CreateClusterRequest, createdByID string) error {
+
+	cmd := exec.CommandContext(ctx, "gcloud", "container", "clusters", "create", req.Cluster.Name,
+		`--project`, b.project,
+		`--region`, b.location,
+		`--create-subnetwork`, ``,
+		`--enable-ip-alias`,
+		`--num-nodes`, `1`,
+		`--cluster-version`, req.Cluster.InitialClusterVersion,
+		`--addons`, `HorizontalPodAutoscaling`,
+		`--labels`, fmt.Sprintf(`%s=%s`, GKECreateLabel, createdByID),
+		`--async`,
+	)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	fmt.Println(cmd.String())
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run gcloud CLI: %w", err)
+	}
+
+	return nil
+}
+
+func sanitizeCreatedByID(id string) string {
+	// Replace dots with dashes as dots are not allowed by the CLI:
+	// "It must only contain lowercase letters ([a-z]), numeric characters ([0-9]), underscores (_) and dashes (-)."
+	id = strings.ReplaceAll(id, ".", "-")
+
+	// Truncate to the maximum allowed length.
+	return id[:63]
 }

--- a/pkg/clusters/types/gke/builder_test.go
+++ b/pkg/clusters/types/gke/builder_test.go
@@ -1,0 +1,13 @@
+package gke
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeCreatedByID(t *testing.T) {
+	sanitized := sanitizeCreatedByID("764086051850-6qr4p6gpi6hn506pt8ejuq83di345HUR.apps^googleusercontent$com")
+	require.Equal(t, "764086051850-6qr4p6gpi6hn506pt8ejuq83di345hur-apps-googleuserco", sanitized,
+		"expected disallowed characters to be replaced with dashes, capitals to be lowered, and output to be truncated")
+}

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -15,10 +15,10 @@ import (
 	"time"
 
 	container "cloud.google.com/go/container/apiv1"
+	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
-	containerpb "google.golang.org/genproto/googleapis/container/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -36,6 +36,16 @@ var (
 )
 
 func TestGKECluster(t *testing.T) {
+	t.Run("create subnet (using gcloud CLI)", func(t *testing.T) {
+		testGKECluster(t, true)
+	})
+
+	t.Run("use default subnet (using gRPC API)", func(t *testing.T) {
+		testGKECluster(t, false)
+	})
+}
+
+func testGKECluster(t *testing.T, createSubnet bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*15)
 	defer cancel()
 
@@ -54,6 +64,7 @@ func TestGKECluster(t *testing.T) {
 	t.Logf("configuring the GKE cluster PROJECT=(%s) LOCATION=(%s)", gkeProject, gkeLocation)
 	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation)
 	builder.WithClusterMinorVersion(1, 23)
+	builder.WithCreateSubnet(createSubnet)
 
 	t.Logf("building cluster %s (this can take some time)", builder.Name)
 	cluster, err := builder.Build(ctx)
@@ -81,10 +92,15 @@ func TestGKECluster(t *testing.T) {
 	gkeCluster, err := mgrc.GetCluster(ctx, &getClusterReq)
 	require.NoError(t, err)
 
-	t.Log("verify integrity of the createdBy label")
-	createdBy, ok := gkeCluster.ResourceLabels[gke.GKECreateLabel]
+	t.Log("verify createdBy label exists")
+	_, ok = gkeCluster.ResourceLabels[gke.GKECreateLabel]
 	require.True(t, ok)
-	require.Equal(t, clientID, createdBy)
+	// Do not verify whether the label value is equal to the clientID as it won't be always true
+	// due to required sanitization of the clientID to match label's format requirements.
+
+	if createSubnet {
+		require.NotEqual(t, "default", gkeCluster.Subnetwork)
+	}
 
 	t.Log("loading the gke cluster into a testing environment and deploying kong addon")
 	env, err := environments.NewBuilder().WithAddons(kong.New()).WithExistingCluster(cluster).Build(ctx)


### PR DESCRIPTION
Adds a possibility to create subnets for GKE clusters as a workaround for https://github.com/googleapis/google-cloud-go/issues/7219. 

**E2E tests run**:
```
=== RUN   TestGKECluster
--- PASS: TestGKECluster (0.00s)
=== RUN   TestGKECluster/create_subnet_(using_gcloud_CLI)
=== PAUSE TestGKECluster/create_subnet_(using_gcloud_CLI)
=== CONT  TestGKECluster/create_subnet_(using_gcloud_CLI)
=== CONT  TestGKECluster/create_subnet_(using_gcloud_CLI)
    gke_cluster_test.go:54: configuring GKE cloud environment for tests
=== CONT  TestGKECluster/create_subnet_(using_gcloud_CLI)
    gke_cluster_test.go:59: verifying integrity of the gcloud credentials
=== CONT  TestGKECluster/create_subnet_(using_gcloud_CLI)
    gke_cluster_test.go:66: configuring the GKE cluster PROJECT=(k8s-team-playground) LOCATION=(us-west1-c)
=== CONT  TestGKECluster/create_subnet_(using_gcloud_CLI)
    gke_cluster_test.go:71: building cluster t-29e50135-8269-43d5-8836-6337622beb75 (this can take some time)
=== CONT  TestGKECluster/create_subnet_(using_gcloud_CLI)
    gke_cluster_test.go:75: setting up cleanup for cluster t-29e50135-8269-43d5-8836-6337622beb75
    gke_cluster_test.go:80: verifying that the cluster can be communicated with
    gke_cluster_test.go:83: server version found: v1.23.15-gke.1400
    gke_cluster_test.go:85: verifying that the cluster can be loaded as an existing cluster
    gke_cluster_test.go:89: verifying cluster is labelled properly in GKE
    gke_cluster_test.go:97: verify createdBy label exists
    gke_cluster_test.go:107: loading the gke cluster into a testing environment and deploying kong addon
    gke_cluster_test.go:111: waiting for addons to be ready
=== CONT  TestGKECluster/create_subnet_(using_gcloud_CLI)
    gke_cluster_test.go:114: validating kubernetes cluster version
    gke_cluster_test.go:120: verifying that the kong addon deployed both proxy and controller
    gke_cluster_test.go:133: deploying a test deployment to ensure the environment's cluster is working
    gke_cluster_test.go:143: verifying the underlying pods deploy successfully
    gke_cluster_test.go:152: exposing deployment httpbin via service
    gke_cluster_test.go:161: creating an ingress for service httpbin with ingress.class kong
    gke_cluster_test.go:172: waiting for ingress status update to validate that the kong controller is functioning
    gke_cluster_test.go:181: accessing the deployment via ingress to validate that the kong proxy is functioning
    --- PASS: TestGKECluster/create_subnet_(using_gcloud_CLI) (401.83s)
=== RUN   TestGKECluster/use_default_subnet_(using_gRPC_API)
=== PAUSE TestGKECluster/use_default_subnet_(using_gRPC_API)
=== CONT  TestGKECluster/use_default_subnet_(using_gRPC_API)
=== CONT  TestGKECluster/use_default_subnet_(using_gRPC_API)
    gke_cluster_test.go:54: configuring GKE cloud environment for tests
=== CONT  TestGKECluster/use_default_subnet_(using_gRPC_API)
    gke_cluster_test.go:59: verifying integrity of the gcloud credentials
=== CONT  TestGKECluster/use_default_subnet_(using_gRPC_API)
    gke_cluster_test.go:66: configuring the GKE cluster PROJECT=(k8s-team-playground) LOCATION=(us-west1-c)
=== CONT  TestGKECluster/use_default_subnet_(using_gRPC_API)
    gke_cluster_test.go:71: building cluster t-8459e832-c407-4465-9aa1-b38920ed218e (this can take some time)
    gke_cluster_test.go:75: setting up cleanup for cluster t-8459e832-c407-4465-9aa1-b38920ed218e
    gke_cluster_test.go:80: verifying that the cluster can be communicated with
    gke_cluster_test.go:83: server version found: v1.23.15-gke.1400
    gke_cluster_test.go:85: verifying that the cluster can be loaded as an existing cluster
    gke_cluster_test.go:89: verifying cluster is labelled properly in GKE
    gke_cluster_test.go:97: verify createdBy label exists
    gke_cluster_test.go:107: loading the gke cluster into a testing environment and deploying kong addon
    gke_cluster_test.go:111: waiting for addons to be ready
=== CONT  TestGKECluster/use_default_subnet_(using_gRPC_API)
    gke_cluster_test.go:114: validating kubernetes cluster version
    gke_cluster_test.go:120: verifying that the kong addon deployed both proxy and controller
    gke_cluster_test.go:133: deploying a test deployment to ensure the environment's cluster is working
    gke_cluster_test.go:143: verifying the underlying pods deploy successfully
    gke_cluster_test.go:152: exposing deployment httpbin via service
    gke_cluster_test.go:161: creating an ingress for service httpbin with ingress.class kong
    gke_cluster_test.go:172: waiting for ingress status update to validate that the kong controller is functioning
    gke_cluster_test.go:181: accessing the deployment via ingress to validate that the kong proxy is functioning
    --- PASS: TestGKECluster/use_default_subnet_(using_gRPC_API) (384.59s)
PASS
```
