### PR TITLE
feat(gke): allow synchronous cluster teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
   [#490](https://github.com/Kong/kubernetes-testing-framework/pull/490)
 - GKE cluster is able to wait for its cleanup synchronously. 
   [#491](https://github.com/Kong/kubernetes-testing-framework/pull/491)
-
 - MetalLB addon will use an extended timeout when fetching manifests from GH which 
   should improve its stability. 
   [#492](https://github.com/Kong/kubernetes-testing-framework/pull/492)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.25.0
+
+- GKE cluster is able to wait for its cleanup synchronously. 
+  [#491](https://github.com/Kong/kubernetes-testing-framework/pull/491)
 
 ## v0.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.25.0
+## Unreleased
 
 - GKE cluster is able to wait for its cleanup synchronously. 
   [#491](https://github.com/Kong/kubernetes-testing-framework/pull/491)

--- a/pkg/clusters/types/gke/cluster.go
+++ b/pkg/clusters/types/gke/cluster.go
@@ -119,9 +119,11 @@ func (c *Cluster) Cleanup(ctx context.Context) error {
 			return err
 		}
 
-		fullTeardownOpName := fmt.Sprintf("projects/%s/locations/%s/operations/%s", c.project, c.location, teardownOp.Name)
-		if err := waitForTeardown(ctx, mgrc, fullTeardownOpName); err != nil {
-			return err
+		if c.waitForTeardown {
+			fullTeardownOpName := fmt.Sprintf("projects/%s/locations/%s/operations/%s", c.project, c.location, teardownOp.Name)
+			if err := waitForTeardown(ctx, mgrc, fullTeardownOpName); err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/pkg/clusters/types/gke/cluster.go
+++ b/pkg/clusters/types/gke/cluster.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	container "cloud.google.com/go/container/apiv1"
+	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/blang/semver/v4"
 	"google.golang.org/api/option"
 	"k8s.io/client-go/kubernetes"
@@ -22,14 +24,15 @@ import (
 
 // Cluster is a clusters.Cluster implementation backed by Google Kubernetes Engine (GKE)
 type Cluster struct {
-	name      string
-	project   string
-	location  string
-	jsonCreds []byte
-	client    *kubernetes.Clientset
-	cfg       *rest.Config
-	addons    clusters.Addons
-	l         *sync.RWMutex
+	name            string
+	project         string
+	location        string
+	jsonCreds       []byte
+	waitForTeardown bool
+	client          *kubernetes.Clientset
+	cfg             *rest.Config
+	addons          clusters.Addons
+	l               *sync.RWMutex
 }
 
 // NewFromExistingWithEnv provides a new clusters.Cluster backed by an existing GKE cluster,
@@ -111,11 +114,40 @@ func (c *Cluster) Cleanup(ctx context.Context) error {
 		}
 		defer mgrc.Close()
 
-		_, err = deleteCluster(ctx, mgrc, c.name, c.project, c.location)
-		return err
+		teardownOp, err := deleteCluster(ctx, mgrc, c.name, c.project, c.location)
+		if err != nil {
+			return err
+		}
+
+		fullTeardownOpName := fmt.Sprintf("projects/%s/locations/%s/operations/%s", c.project, c.location, teardownOp.Name)
+		if err := waitForTeardown(ctx, mgrc, fullTeardownOpName); err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	return nil
+}
+
+func waitForTeardown(ctx context.Context, mgrc *container.ClusterManagerClient, teardownOpName string) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			op, err := mgrc.GetOperation(ctx, &containerpb.GetOperationRequest{Name: teardownOpName})
+			if err != nil {
+				return err
+			}
+			if op.Status == containerpb.Operation_DONE {
+				return nil
+			}
+		}
+	}
 }
 
 func (c *Cluster) Client() *kubernetes.Clientset {

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -54,6 +54,7 @@ func TestGKECluster(t *testing.T) {
 	t.Logf("configuring the GKE cluster PROJECT=(%s) LOCATION=(%s)", gkeProject, gkeLocation)
 	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation)
 	builder.WithClusterMinorVersion(1, 23)
+	builder.WithWaitForTeardown(true)
 
 	t.Logf("building cluster %s (this can take some time)", builder.Name)
 	cluster, err := builder.Build(ctx)
@@ -61,6 +62,7 @@ func TestGKECluster(t *testing.T) {
 
 	t.Logf("setting up cleanup for cluster %s", cluster.Name())
 	defer func() {
+		t.Log("running cluster cleanup")
 		assert.NoError(t, cluster.Cleanup(ctx))
 	}()
 

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -62,7 +62,7 @@ func TestGKECluster(t *testing.T) {
 
 	t.Logf("setting up cleanup for cluster %s", cluster.Name())
 	defer func() {
-		t.Log("running cluster cleanup")
+		t.Logf("running cluster cleanup for %s", cluster.Name())
 		assert.NoError(t, cluster.Cleanup(ctx))
 	}()
 


### PR DESCRIPTION
`DeleteCluster` operation is asynchronous therefore we need to poll the operation status to tell if it's done. 

Should resolve #485.