### PR TITLE
fix(metallb): extend timeout when fetching manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - MetalLB addon will use an extended timeout when fetching manifests from GH which 
   should improve its stability. 
-  [#]()
+  [#492](https://github.com/Kong/kubernetes-testing-framework/pull/492)
 
 ## v0.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- MetalLB addon will use an extended timeout when fetching manifests from GH which 
+  should improve its stability. 
+  [#]()
+
 ## v0.24.1
 
 - Golang dependencies for several Kubernetes libraries were updated to

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -144,7 +144,7 @@ func (a *addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (
 var (
 	defaultStartIP = net.ParseIP("0.0.0.100")
 	defaultEndIP   = net.ParseIP("0.0.0.250")
-	metalManifest  = "https://github.com/metallb/metallb/config/native?ref=v0.13.7?timeout=2m"
+	metalManifest  = "https://github.com/metallb/metallb/config/native?ref=v0.13.7&timeout=2m"
 	secretKeyLen   = 128
 )
 

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -144,7 +144,7 @@ func (a *addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (
 var (
 	defaultStartIP = net.ParseIP("0.0.0.100")
 	defaultEndIP   = net.ParseIP("0.0.0.250")
-	metalManifest  = "https://github.com/metallb/metallb/config/native?ref=v0.13.7"
+	metalManifest  = "https://github.com/metallb/metallb/config/native?ref=v0.13.7?timeout=2m"
 	secretKeyLen   = 128
 )
 


### PR DESCRIPTION
The default timeout of 27s proved many times it's not enough, making our tests unstable (example run failed due to that: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/3884417735/jobs/6627705020). This PR extends the timeout to 2 minutes which I believe should be enough to make the addon more stable. 

Based on https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md instructions.