### PR TITLE
fix(ci): add GH token to release workflow to overcome API rate limits

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -55,11 +55,13 @@ jobs:
     - name: run integration tests
       run: make test.integration
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
     - name: run e2e tests
       run: make test.e2e
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
         GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}


### PR DESCRIPTION
Affected workflow run: https://github.com/Kong/kubernetes-testing-framework/actions/runs/3891847929/jobs/6643910381