### PR TITLE
fix: truncate only when allowed length exceeded

### DIFF
--- a/pkg/clusters/types/gke/builder.go
+++ b/pkg/clusters/types/gke/builder.go
@@ -274,9 +274,10 @@ func sanitizeCreatedByID(id string) string {
 	}
 
 	// Truncate to the maximum allowed length.
-	if s := builder.String(); len(s) > 63 {
-		return s[:63]
-	} else {
-		return s
+	const maxAllowedLength = 63
+	s := builder.String()
+	if len(s) > maxAllowedLength {
+		return s[:maxAllowedLength]
 	}
+	return s
 }

--- a/pkg/clusters/types/gke/builder.go
+++ b/pkg/clusters/types/gke/builder.go
@@ -274,5 +274,9 @@ func sanitizeCreatedByID(id string) string {
 	}
 
 	// Truncate to the maximum allowed length.
-	return builder.String()[:63]
+	if s := builder.String(); len(s) > 63 {
+		return s[:63]
+	} else {
+		return s
+	}
 }

--- a/pkg/clusters/types/gke/builder_test.go
+++ b/pkg/clusters/types/gke/builder_test.go
@@ -26,7 +26,7 @@ func TestSanitizeCreatedByID(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		t.Run(tc.input, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			sanitized := sanitizeCreatedByID(tc.input)
 			require.Equal(t, tc.expected, sanitized)
 		})

--- a/pkg/clusters/types/gke/builder_test.go
+++ b/pkg/clusters/types/gke/builder_test.go
@@ -7,7 +7,28 @@ import (
 )
 
 func TestSanitizeCreatedByID(t *testing.T) {
-	sanitized := sanitizeCreatedByID("764086051850-6qr4p6gpi6hn506pt8ejuq83di345HUR.apps^googleusercontent$com")
-	require.Equal(t, "764086051850-6qr4p6gpi6hn506pt8ejuq83di345hur-apps-googleuserco", sanitized,
-		"expected disallowed characters to be replaced with dashes, capitals to be lowered, and output to be truncated")
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "longer than allowed",
+			input:    "764086051850-6qr4p6gpi6hn506pt8ejuq83di345HUR.apps^googleusercontent$com",
+			expected: "764086051850-6qr4p6gpi6hn506pt8ejuq83di345hur-apps-googleuserco",
+		},
+		{
+			name:     "short",
+			input:    "764086051850",
+			expected: "764086051850",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			sanitized := sanitizeCreatedByID(tc.input)
+			require.Equal(t, tc.expected, sanitized)
+		})
+	}
 }


### PR DESCRIPTION
Thankfully that was caught by the E2E test in the release pipeline: https://github.com/Kong/kubernetes-testing-framework/actions/runs/3891847929/jobs/6644691387 😓 