### PR TITLE
refactor(gke): use grpc when createSubnet set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- gRPC API is used instead of gcloud CLI when createSubnetwork is enabled in 
+  GKE cluster builder.
+  [#498](https://github.com/Kong/kubernetes-testing-framework/pull/498)
+
 ## v0.25.0 
 
 - GKE cluster builder allows creating a subnet for the cluster instead of using 


### PR DESCRIPTION
When reading the documentation again, I realized that the `--create-subnet` can be used in the gRPC API: https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips#api_1. 

