### PR TITLE
ci: use gh in install.sh for artifacts download

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,11 @@
 name: tests
 
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:
@@ -10,6 +16,21 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  installer-tests:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+
+    - name: run installer script
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: ./docs/install.sh
+
+    - name: run ktf
+      run: ~/.local/bin/ktf --help
+
   unit-tests:
     runs-on: ubuntu-latest
     steps:

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -10,8 +10,7 @@ BASE="kong/kubernetes-testing-framework"
 
 echo "INFO: verifying operating system compatibility"
 
-OSTYPE=$(uname -s)
-OSTYPE=$(echo "${OSTYPE,,}") # convert to lower case
+OSTYPE=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 if [ "$OSTYPE" != "linux" ]; then
     if [ "$OSTYPE" != "darwin" ]; then
@@ -26,44 +25,67 @@ fi
 
 echo "INFO: verifying cpu architecture compatibility"
 
-ARCH=$(uname -m)
-ARCH=$(echo "${ARCH,,}") # convert to lower case
+ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 
 if [ "$ARCH" = x86_64 ]; then
     ARCH="amd64"
 fi
+if [ "$ARCH" = aarch64 ]; then
+    ARCH="arm64"
+fi
 
-if [ "$ARCH" != "amd64" ]; then
+if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" ]]; then
     echo "Error: ${ARCH} is not a supported architecture at this time."
     exit 1
 fi
 
-# ------------------------------------------------------------------------------
-# Determine Latest Release
-# ------------------------------------------------------------------------------
-
-LATEST_RELEASE=$(curl -s https://api.github.com/repos/${BASE}/releases/latest | perl -ne 'print $1 if m{"name": "(v[0-9]+\.[0-9]+\.[0-9]+.*)"}')
-
-if [ "$LATEST_RELEASE" = "" ]; then
-    echo "Error: could not find latest release for ${BASE}!${LATEST_RELEASE}"
-    exit 1
-fi
-
-echo "INFO: the latest release of ${BASE} was determined to be ${LATEST_RELEASE}"
-
-# ------------------------------------------------------------------------------
-# Downloading Binary & Checksums
-# ------------------------------------------------------------------------------
-
-DOWNLOAD_URL="https://github.com/${BASE}/releases/download/${LATEST_RELEASE}/ktf.${OSTYPE}.${ARCH}"
-DOWNLOAD_CHECKSUMS_URL="https://github.com/${BASE}/releases/download/${LATEST_RELEASE}/CHECKSUMS"
 TEMPDIR=$(mktemp -d)
 
-echo "INFO: downloading ktf cli for ${OSTYPE}/${ARCH}"
-curl -L --proto '=https' --tlsv1.2 -sSf ${DOWNLOAD_URL} > ${TEMPDIR}/ktf.${OSTYPE}.${ARCH}
+function download_with_curl()
+{
+    echo "INFO: downloading ktf via curl"
 
-echo "INFO: downloading checksums for release ${LATEST_RELEASE}"
-curl -L --proto '=https' --tlsv1.2 -sSf ${DOWNLOAD_CHECKSUMS_URL} > ${TEMPDIR}/CHECKSUMS
+    # ------------------------------------------------------------------------------
+    # Determine Latest Release
+    # ------------------------------------------------------------------------------
+
+    LATEST_RELEASE=$(curl -s https://api.github.com/repos/${BASE}/releases/latest | perl -ne 'print $1 if m{"name": "(v[0-9]+\.[0-9]+\.[0-9]+.*)"}')
+
+    if [ "$LATEST_RELEASE" = "" ]; then
+        echo "Error: could not find latest release for ${BASE}!${LATEST_RELEASE}"
+        exit 1
+    fi
+
+    echo "INFO: the latest release of ${BASE} was determined to be ${LATEST_RELEASE}"
+
+    # ------------------------------------------------------------------------------
+    # Downloading Binary & Checksums
+    # ------------------------------------------------------------------------------
+
+    DOWNLOAD_URL="https://github.com/${BASE}/releases/download/${LATEST_RELEASE}/ktf.${OSTYPE}.${ARCH}"
+    DOWNLOAD_CHECKSUMS_URL="https://github.com/${BASE}/releases/download/${LATEST_RELEASE}/CHECKSUMS"
+
+    echo "INFO: downloading ktf cli for ${OSTYPE}/${ARCH}"
+    curl -L --proto '=https' --tlsv1.2 -sSf ${DOWNLOAD_URL} > ${TEMPDIR}/ktf.${OSTYPE}.${ARCH}
+
+    echo "INFO: downloading checksums for release ${LATEST_RELEASE}"
+    curl -L --proto '=https' --tlsv1.2 -sSf ${DOWNLOAD_CHECKSUMS_URL} > ${TEMPDIR}/CHECKSUMS
+}
+
+function download_with_gh()
+{
+    echo "INFO: Downloading ktf via gh"
+    gh release download --dir ${TEMPDIR} --pattern "ktf.${OSTYPE}.${ARCH}" --repo "${BASE}"
+    gh release download --dir ${TEMPDIR} --pattern "CHECKSUMS" --repo "${BASE}"
+    LATEST_RELEASE=$(gh release view --repo "${BASE}" --json tagName --template {{.tagName}})
+}
+
+if gh --version 2>/dev/null 1>/dev/null; then
+    download_with_gh
+else
+    echo "INFO: gh not available on the system, falling back to download via curl"
+    download_with_curl
+fi
 
 # ------------------------------------------------------------------------------
 # Checksum Verification
@@ -77,7 +99,8 @@ popd 1>/dev/null
 # Installation
 # ------------------------------------------------------------------------------
 
-INSTALL_DIRECTORY="${HOME}/.local/bin/" # TODO: will make this dynamic in a later iteration
+INSTALL_DIRECTORY="${HOME}/.local/bin" # TODO: will make this dynamic in a later iteration
+[[ -d "${INSTALL_DIRECTORY}" ]] || mkdir -p "${INSTALL_DIRECTORY}"
 INSTALL_LOCATION="${INSTALL_DIRECTORY}/ktf"
 
 install ${TEMPDIR}/ktf.${OSTYPE}.${ARCH} ${INSTALL_LOCATION}


### PR DESCRIPTION
This PR aims to avoid hitting the API rate limiting by using `gh` which should already be using `GITHUB_TOKEN` on Github's CI.