### PR TITLE
fix: fix codecov flags

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
+        flags: unit-test
         files: unit.coverage.out
         verbose: true
 
@@ -110,7 +111,8 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
-        files: unit.coverage.out,integration.coverage.out
+        flags: integration-test
+        files: integration.coverage.out
         verbose: true
 
   integration-tests-passed:

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,11 @@ test.unit:
 		-v \
 		-covermode=atomic \
 		-coverprofile=unit.coverage.out \
+		-coverpkg=$(PKG_LIST) \
 		./pkg/...
 
 TEST_RUN ?= ""
+PKG_LIST ?= ./pkg/...,./internal/...
 
 .PHONY: test.integration
 test.integration:
@@ -48,6 +50,7 @@ test.integration:
 		-v \
 		-covermode=atomic \
 		-coverprofile=integration.coverage.out \
+		-coverpkg=$(PKG_LIST) \
 		./test/integration/...
 
 .PHONY: test.e2e


### PR DESCRIPTION
This fixes codecov reports by specifying the `-coverpkg` in `go test` invocation.

Without this we were getting empty reports.

Link to report in codecov: https://app.codecov.io/github/Kong/kubernetes-testing-framework/commit/86098a9437aedca75a8e1b4edbb044d7f03cbdd7