### PR TITLE
fix: add retry when applying knative manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add a retry when deploying knative manifests
+  [#520](https://github.com/Kong/kubernetes-testing-framework/pull/520)
+
 ## v0.27.0
 
 - fix cluster cleaner for Gateway API objects

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/avast/retry-go/v4 v4.3.2
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VM
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/avast/retry-go/v4 v4.3.2 h1:x4sTEu3jSwr7zNjya8NTdIN+U88u/jtO/q3OupBoDtM=
+github.com/avast/retry-go/v4 v4.3.2/go.mod h1:rg6XFaiuFYII0Xu3RDbZQkxCofFwruZKW8oEF1jpWiU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=


### PR DESCRIPTION
Sometimes accessing knative manifests fails, e.g.: https://github.com/Kong/kubernetes-testing-framework/actions/runs/4063531683/jobs/6995883947#step:6:48

```
knative_test.go:22: configuring the testing environment
    knative_test.go:26: building the testing environment and Kubernetes cluster
    knative_test.go:28: 
        	Error Trace:	/home/runner/work/kubernetes-testing-framework/kubernetes-testing-framework/test/integration/knative_test.go:28
        	Error:      	Received unexpected error:
        	            	failed to deploy addon knative: knative CRD deployment failed STDOUT=() STDERR=(error: unable to read URL "https://github.com/knative/serving/releases/download/knative-v1.9.0/serving-crds.yaml", server reported 403 Forbidden, status code=403
        	            	): exit status 1
        	Test:       	TestEnvironmentWithKnative
--- FAIL: TestEnvironmentWithKnative ([49](https://github.com/Kong/kubernetes-testing-framework/actions/runs/4063531683/jobs/6995883947#step:6:50).97s)
```

This PR adds a retry for this step to avoid such situations.