### PR TITLE
feat: add retry to helm installation and knative manifests apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## Unreleased
+## v0.28.0
 
-- Add a retry when deploying knative manifests
+- Add arm64 artifacts
+  [#518](https://github.com/Kong/kubernetes-testing-framework/pull/518)
+- Add a retry when deploying knative manifests and during kong chart installation
   [#520](https://github.com/Kong/kubernetes-testing-framework/pull/520)
+  [#523](https://github.com/Kong/kubernetes-testing-framework/pull/523)
 
 ## v0.27.0
 

--- a/internal/retry/command.go
+++ b/internal/retry/command.go
@@ -1,0 +1,84 @@
+package retry
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	retryCount = 10
+	retryWait  = 3 * time.Second
+)
+
+type Doer interface {
+	Do(ctx context.Context) error
+	DoWithErrorHandling(ctx context.Context, errorFunc ErrorFunc) error
+}
+
+type ErrorFunc func(error, *bytes.Buffer, *bytes.Buffer) error
+
+type commandDoer struct {
+	cmd  string
+	args []string
+}
+
+func Command(cmd string, args ...string) Doer {
+	return commandDoer{
+		cmd:  cmd,
+		args: args,
+	}
+}
+
+func (c commandDoer) Do(ctx context.Context) error {
+	return retry.Do(func() error {
+		cmd, stdout, stderr := c.createCmd(ctx)
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("command %q with args [%v] failed STDOUT=(%s) STDERR=(%s): %w",
+				c.cmd, c.args, stdout.String(), stderr.String(), err,
+			)
+		}
+		return nil
+	},
+		c.createOpts(ctx)...,
+	)
+}
+
+func (c commandDoer) DoWithErrorHandling(ctx context.Context, errorFunc ErrorFunc) error {
+	return retry.Do(func() error {
+		cmd, stdout, stderr := c.createCmd(ctx)
+		err := cmd.Run()
+		return errorFunc(err, stdout, stderr)
+	},
+		c.createOpts(ctx)...,
+	)
+}
+
+func (c commandDoer) createCmd(ctx context.Context) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd := exec.CommandContext(ctx, c.cmd, c.args...) //nolint:gosec
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd, stdout, stderr
+}
+
+func (c commandDoer) createOpts(ctx context.Context) []retry.Option {
+	return []retry.Option{
+		retry.Context(ctx),
+		retry.Delay(retryWait),
+		retry.Attempts(retryCount),
+		retry.DelayType(retry.FixedDelay),
+		retry.OnRetry(func(_ uint, err error) {
+			logrus.WithError(err).
+				WithField("args", c.args).
+				Errorf("failed running %s", c.cmd)
+		}),
+	}
+}

--- a/pkg/clusters/cleanup.go
+++ b/pkg/clusters/cleanup.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -61,6 +61,7 @@ func TestKongAddonWithCustomImage(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name(), func(t *testing.T) {
 			t.Parallel()
 			testKongAddonWithCustomImage(t, tc)


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds the `retry` package that can be used to trigger commands that should be retried in case of a failure.

### Which issue does this solve

Closes #476 and #466