### PR TITLE
fix(ci): fix release names

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,12 +102,9 @@ jobs:
 
     - name: Release
       uses: softprops/action-gh-release@v1
-      id: create_release
       with:
-        draft: true
-        prerelease: true
-        name: ${{ github.ref }}
-        tag_name: ${{ github.ref }}
+        draft: false
+        prerelease: false
         files: |
           CHECKSUMS
           ktf.*


### PR DESCRIPTION
- No need to specify the release and tag names, otherwise they'll have `refs/tags/` prefix
- Don't mark releases as drafts or prereleases