### PR TITLE
fix(gke): wait for cluster create operation done

### DIFF
--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -245,7 +245,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	}
 
 	// if the dbmode is postgres, set several related values
-	args := []string{"--kubeconfig", kubeconfig.Name(), "install", DefaultDeploymentName, "kong/kong"}
+	args := []string{"--kubeconfig", kubeconfig.Name(), "upgrade", "--install", DefaultDeploymentName, "kong/kong"}
 	if a.proxyDBMode == PostgreSQL {
 		a.deployArgs = append(a.deployArgs, []string{
 			"--set", "env.database=postgres",
@@ -290,7 +290,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 
 	// set the service type of the proxy's Kubernetes service
 	if a.proxyServiceType == corev1.ServiceTypeExternalName {
-		return fmt.Errorf("Service type ExternalName is not currently supported")
+		return errors.New("service type ExternalName is not currently supported")
 	}
 	a.deployArgs = append(a.deployArgs, []string{"--set", "proxy.type=" + string(a.proxyServiceType)}...)
 

--- a/pkg/clusters/types/gke/operations.go
+++ b/pkg/clusters/types/gke/operations.go
@@ -1,0 +1,36 @@
+package gke
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	container "cloud.google.com/go/container/apiv1"
+	"cloud.google.com/go/container/apiv1/containerpb"
+)
+
+// fullOperationName returns a full operation name that is needed when querying its status.
+func fullOperationName(project, location, operationName string) string {
+	return fmt.Sprintf("projects/%s/locations/%s/operations/%s", project, location, operationName)
+}
+
+// waitForOperationDone waits for a given operation to be done. It's going to be aborted when passed context gets cancelled.
+func waitForOperationDone(ctx context.Context, mgrc *container.ClusterManagerClient, operationName string) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			op, err := mgrc.GetOperation(ctx, &containerpb.GetOperationRequest{Name: operationName})
+			if err != nil {
+				return err
+			}
+			if op.Status == containerpb.Operation_DONE {
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/clusters/types/gke/utils.go
+++ b/pkg/clusters/types/gke/utils.go
@@ -23,11 +23,10 @@ import (
 func deleteCluster(
 	ctx context.Context,
 	c *container.ClusterManagerClient,
-	name, project, location string,
+	fullClusterName string,
 ) (*containerpb.Operation, error) {
 	// tear down the cluster and return the teardown operation
-	fullname := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, name)
-	req := containerpb.DeleteClusterRequest{Name: fullname}
+	req := containerpb.DeleteClusterRequest{Name: fullClusterName}
 	return c.DeleteCluster(ctx, &req)
 }
 
@@ -139,4 +138,8 @@ func clientAuthFromCreds(ctx context.Context, jsonCreds []byte) (*container.Clus
 	}
 
 	return mgrc, oauthToken.AccessToken, nil
+}
+
+func fullClusterName(project, location, name string) string {
+	return fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, name)
 }

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -36,11 +36,11 @@ var (
 )
 
 func TestGKECluster(t *testing.T) {
-	t.Run("create subnet (using gcloud CLI)", func(t *testing.T) {
+	t.Run("create subnet", func(t *testing.T) {
 		testGKECluster(t, true)
 	})
 
-	t.Run("use default subnet (using gRPC API)", func(t *testing.T) {
+	t.Run("use default subnet", func(t *testing.T) {
 		testGKECluster(t, false)
 	})
 }
@@ -72,10 +72,11 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 	require.NoError(t, err)
 
 	t.Logf("setting up cleanup for cluster %s", cluster.Name())
-	defer func() {
+	t.Cleanup(func() {
 		t.Logf("running cluster cleanup for %s", cluster.Name())
-		assert.NoError(t, cluster.Cleanup(ctx))
-	}()
+		// don't use test ctx as it may be cancelled already
+		assert.NoError(t, cluster.Cleanup(context.Background()))
+	})
 
 	t.Log("verifying that the cluster can be communicated with")
 	version, err := cluster.Client().ServerVersion()

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -83,6 +83,9 @@ func testKongAddonWithCustomImage(t *testing.T, tc customImageTest) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
+	err := <-env.WaitForReady(ctx)
+	require.NoError(t, err)
+
 	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())
 	defer func() {
 		t.Logf("cleaning up environment %s and cluster %s", env.Name(), env.Cluster().Name())


### PR DESCRIPTION
Adds waiting for the CreateCluster operation to be completed additionally to verifying the cluster's state being ready. Also fixes e2es to always cleanup the cluster.

Aims to fix #533.