### PR TITLE
fix(kong): upgrade --install and handle error properly

### DIFF
--- a/internal/retry/command.go
+++ b/internal/retry/command.go
@@ -50,6 +50,8 @@ func (c commandDoer) Do(ctx context.Context) error {
 	)
 }
 
+// DoWithErrorHandling executes the command and runs errorFunc passing a resulting err, stdout and stderr to be handled
+// by the caller. The errorFunc is going to be called always when the resulting err != nil.
 func (c commandDoer) DoWithErrorHandling(ctx context.Context, errorFunc ErrorFunc) error {
 	return retry.Do(func() error {
 		cmd, stdout, stderr := c.createCmd(ctx)

--- a/internal/retry/command.go
+++ b/internal/retry/command.go
@@ -54,7 +54,10 @@ func (c commandDoer) DoWithErrorHandling(ctx context.Context, errorFunc ErrorFun
 	return retry.Do(func() error {
 		cmd, stdout, stderr := c.createCmd(ctx)
 		err := cmd.Run()
-		return errorFunc(err, stdout, stderr)
+		if err != nil {
+			return errorFunc(err, stdout, stderr)
+		}
+		return nil
 	},
 		c.createOpts(ctx)...,
 	)

--- a/internal/retry/command.go
+++ b/internal/retry/command.go
@@ -51,7 +51,7 @@ func (c commandDoer) Do(ctx context.Context) error {
 }
 
 // DoWithErrorHandling executes the command and runs errorFunc passing a resulting err, stdout and stderr to be handled
-// by the caller. The errorFunc is going to be called always when the resulting err != nil.
+// by the caller. The errorFunc is going to be called only when the resulting err != nil.
 func (c commandDoer) DoWithErrorHandling(ctx context.Context, errorFunc ErrorFunc) error {
 	return retry.Do(func() error {
 		cmd, stdout, stderr := c.createCmd(ctx)

--- a/internal/retry/command_test.go
+++ b/internal/retry/command_test.go
@@ -1,0 +1,42 @@
+package retry_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kubernetes-testing-framework/internal/retry"
+)
+
+func TestDoWithErrorHandling(t *testing.T) {
+	t.Run("succeeded command won't call the errorFunc", func(t *testing.T) {
+		cmd := retry.Command("echo", "test")
+
+		itShouldntGetCalled := func(err error, _ *bytes.Buffer, _ *bytes.Buffer) error {
+			t.Error("this function shouldn't be called because there was no error running command")
+			return err
+		}
+		err := cmd.DoWithErrorHandling(context.Background(), itShouldntGetCalled)
+		require.NoError(t, err)
+	})
+
+	t.Run("failing command will call the errorFunc", func(t *testing.T) {
+		cmd := retry.Command("unknown-command")
+
+		wasCalled := false
+		itShouldBeCalled := func(err error, _ *bytes.Buffer, _ *bytes.Buffer) error {
+			wasCalled = true
+			return err
+		}
+
+		// Wait just a second to not make tests run too long. It's enough to know the errorFunc was called at least once.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		err := cmd.DoWithErrorHandling(ctx, itShouldBeCalled)
+		require.Error(t, err)
+		require.True(t, wasCalled, "expected errorFunc to be called because the command has failed")
+	})
+}

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -83,7 +83,7 @@ func testKongAddonWithCustomImage(t *testing.T, tc customImageTest) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
-	err := <-env.WaitForReady(ctx)
+	err = <-env.WaitForReady(ctx)
 	require.NoError(t, err)
 
 	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -83,6 +83,9 @@ func testKongAddonWithCustomImage(t *testing.T, tc customImageTest) {
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
+	err := <-env.WaitForReady(ctx)
+	require.NoError(t, err)
+
 	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())
 	defer func() {
 		t.Logf("cleaning up environment %s and cluster %s", env.Name(), env.Cluster().Name())


### PR DESCRIPTION
I believe this should fix #533 root cause.

https://github.com/Kong/kubernetes-testing-framework/pull/523/files introduced `DoWithErrorHandling` which changed behavior of the helm install step of Kong addon. 

Before:
```
if err := cmd.Run(); err != nil {
		if !strings.Contains(stderr.String(), "cannot re-use") { // ignore if addon is already deployed
			return fmt.Errorf("%s: %w", stderr.String(), err)
		}
	}
```
 
After: 
```
return retry.
		Command("helm", args...).
		DoWithErrorHandling(ctx, func(err error, _, stderr *bytes.Buffer) error {
			if !strings.Contains(stderr.String(), "cannot re-use") {
				return fmt.Errorf("%s: %w", stderr, err)
			}
			return nil
		})
```

In the `after` version because of `DoWithErrorHandling` implementation calling the error handling function always, despite the error value, we were ending up retrying many times even if an error was nil.