### PR TITLE
fix(tests): fix TestKongAddonWithCustomImage which was waiting for LoadBalancer IP without metallb installed

### DIFF
--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -48,12 +48,6 @@ func TestKongAddonWithCustomImage(t *testing.T) {
 	tests := []customImageTest{
 		{
 			controllerImageRepo: "kong/kubernetes-ingress-controller",
-			controllerImageTag:  "2.3.0",
-			proxyImageRepo:      "kong",
-			proxyImageTag:       "2.7",
-		},
-		{
-			controllerImageRepo: "kong/kubernetes-ingress-controller",
 			controllerImageTag:  "2.3.1",
 			proxyImageRepo:      "kong",
 			proxyImageTag:       "2.8",


### PR DESCRIPTION
Related https://github.com/Kong/kubernetes-testing-framework/issues/540

This PR also removes a broken test case which causes for some reason KIC to emit the following errors:

```
ingress-controller Error: either cert/key files OR cert/key values must be provided, or none
ingress-controller Error: either cert/key files OR cert/key values must be provided, or none
```