### PR TITLE
fix(ci): use Personal Access Token to trigger release from release-testing workflow

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -21,7 +21,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        token: ${{ secrets.PAT_GITHUB }}
 
     - name: setup golang
       uses: actions/setup-go@v3
@@ -77,7 +76,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        token: ${{ secrets.PAT_GITHUB }}
 
     - name: setup golang
       uses: actions/setup-go@v3
@@ -119,7 +117,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        token: ${{ secrets.PAT_GITHUB }}
 
     - name: setup golang
       uses: actions/setup-go@v3
@@ -155,6 +152,13 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        # This is needed to trigger another workflow, specifically release workflow
+        # which listens to pushing "v*" tags.
+        # > When you use the repository’s GITHUB_TOKEN to perform tasks on behalf
+        # > of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not
+        # > create a new workflow run.
+        # ref: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+        token: ${{ secrets.PAT_GITHUB }}
 
     # --------------------------------------------------------------------------
     # Release Tagging


### PR DESCRIPTION
It seems that we have already solved this in #406 but then reorganized stuff and forgot the token 🤦 .

We don't need this in other jobs in the workflow because the only thing we care about it to trigger the release workflow.

Fixes #337.