### PR TITLE
ci: skip e2es if no GOOGLE_APPLICATION_CREDENTIALS set

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -147,29 +147,31 @@ jobs:
   e2e-tests:
     environment: gcloud
     runs-on: ubuntu-latest
-    env:
-      PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
     steps:
+      - name: Detect if we should run (have required secrets)
+        id: detect_if_should_run
+        run: echo "result=${{ secrets.PULP_PASSWORD != '' && secrets.GOOGLE_APPLICATION_CREDENTIALS != '' }}" >> $GITHUB_OUTPUT
+
       - uses: Kong/kong-license@master
-        if: env.PULP_PASSWORD != ''
+        if: steps.detect_if_should_run.outputs.result
         id: license
         with:
           password: ${{ secrets.PULP_PASSWORD }}
 
       - name: checkout repository
-        if: env.PULP_PASSWORD != ''
+        if: steps.detect_if_should_run.outputs.result
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: setup golang
-        if: env.PULP_PASSWORD != ''
+        if: steps.detect_if_should_run.outputs.result
         uses: actions/setup-go@v3
         with:
           go-version: '^1.19'
 
       - name: cache go modules
-        if: env.PULP_PASSWORD != ''
+        if: steps.detect_if_should_run.outputs.result
         uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -178,7 +180,7 @@ jobs:
             ${{ runner.os }}-build-codegen-
 
       - name: run e2e tests
-        if: env.PULP_PASSWORD != ''
+        if: steps.detect_if_should_run.outputs.result
         run: make test.e2e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Should solve https://github.com/Kong/kubernetes-testing-framework/issues/547.