### PR TITLE
chore: add more descriptive errors when commands fail

### DIFF
--- a/pkg/clusters/types/kind/builder.go
+++ b/pkg/clusters/types/kind/builder.go
@@ -68,7 +68,7 @@ func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 
 	if b.calicoCNI {
 		if err := b.disableDefaultCNI(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed disabling default CNI for kind cluster: %w", err)
 		}
 
 		// if calico is enabled, we can't effectively wait for the cluster to

--- a/pkg/clusters/utils.go
+++ b/pkg/clusters/utils.go
@@ -307,7 +307,10 @@ func kubectlSubcommandWithYAML(ctx context.Context, cluster Cluster, subcommand,
 		cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfig.Name(), subcommand, "-f", yaml) //nolint:gosec
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
-		return cmd.Run()
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("command %q failed STDERR=(%s) STDERR=(%s): %w", cmd.String(), stdout.String(), stderr.String(), err)
+		}
+		return nil
 	}
 
 	// configure the command to read YAML from STDIN


### PR DESCRIPTION
To prevent vague errors printed e.g. in tests: https://github.com/Kong/kubernetes-testing-framework/actions/runs/4143881679/jobs/7166276368#step:6:18

```
=== RUN   TestKindClusterWithCalicoCNI
=== PAUSE TestKindClusterWithCalicoCNI
=== CONT  TestKindClusterWithCalicoCNI
    calico_test.go:28: configuring the test environment with Calico enabled
    calico_test.go:31: building the testing environment and Kubernetes cluster
    calico_test.go:33: 
        	Error Trace:	/home/runner/work/kubernetes-testing-framework/kubernetes-testing-framework/test/integration/calico_test.go:33
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestKindClusterWithCalicoCNI
--- FAIL: TestKindClusterWithCalicoCNI (36.45s)
```

this PR adds more descriptive errors in several places where we're running subcommands.