### PR TITLE
fix: fix calico manifests URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fix calico manifests URL
+  [#555](https://github.com/Kong/kubernetes-testing-framework/pull/555)
+
 ## v0.28.1
 
 - Fix command error handling when error is `nil`

--- a/pkg/clusters/types/kind/utils.go
+++ b/pkg/clusters/types/kind/utils.go
@@ -42,7 +42,7 @@ func NewFromExisting(name string) (clusters.Cluster, error) {
 // -----------------------------------------------------------------------------
 
 const (
-	defaultCalicoManifests = "https://projectcalico.docs.tigera.io/manifests/calico.yaml"
+	defaultCalicoManifests = "https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml"
 )
 
 // -----------------------------------------------------------------------------
@@ -148,5 +148,5 @@ func (b *Builder) disableDefaultCNI() error {
 		return err
 	}
 
-	return os.WriteFile(*b.configPath, configYAML, 0600) //nolint:gomnd
+	return os.WriteFile(*b.configPath, configYAML, 0o600) //nolint:gomnd
 }


### PR DESCRIPTION
It seems that the old URL for calico manifests: https://projectcalico.docs.tigera.io/manifests/calico.yaml is not available anymore.

[Calico docs](https://docs.tigera.io/calico/3.25/getting-started/kubernetes/quickstart) explicitly mention a version in the URL so something like this has to be used: https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml

Since these are in the repo and not attached to release artifacts we have to pick a tag or a branch. I reckon using `master` is not the best idea so let's stick to the latest version ATM. 

Here's a CI run that has the error printed out: https://github.com/Kong/kubernetes-testing-framework/actions/runs/4144020162/jobs/7166576869

```
=== RUN   TestKindClusterWithCalicoCNI
=== PAUSE TestKindClusterWithCalicoCNI
=== CONT  TestKindClusterWithCalicoCNI
    calico_test.go:28: configuring the test environment with Calico enabled
    calico_test.go:31: building the testing environment and Kubernetes cluster
    calico_test.go:33: 
        	Error Trace:	/home/runner/work/kubernetes-testing-framework/kubernetes-testing-framework/test/integration/calico_test.go:33
        	Error:      	Received unexpected error:
        	            	command "/usr/local/bin/kubectl --kubeconfig /tmp/-kubeconfig-0[18](https://github.com/Kong/kubernetes-testing-framework/actions/runs/4144020162/jobs/7166576869#step:6:19)10501-bb63-4d53-bed9-b9b99a90ae582785230788 apply -f https://projectcalico.docs.tigera.io/manifests/calico.yaml" failed STDERR=() STDERR=(error: unable to read URL "https://projectcalico.docs.tigera.io/manifests/calico.yaml", server reported 404 Not Found, status code=404
        	            	): exit status 1
        	Test:       	TestKindClusterWithCalicoCNI
--- FAIL: TestKindClusterWithCalicoCNI (37.66s)
```