### PR TITLE
chore: bump default enterprise gateway image to 3.1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Bump Kong Gateway Enterprise default image to 3.1.1.3
+  [#566](https://github.com/Kong/kubernetes-testing-framework/pull/566)
+
 ## v0.29.0
 
 - Fix an endless loop in cleaner's `Cleanup()` when a namespace to be deleted

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -48,7 +48,7 @@ const (
 	DefaultEnterpriseImageRepo = "kong/kong-gateway"
 
 	// DefaultEnterpriseImageTag latest kong enterprise image tag
-	DefaultEnterpriseImageTag = "2.7.0.0-alpine"
+	DefaultEnterpriseImageTag = "3.1.1.3-alpine"
 
 	// DefaultEnterpriseLicenseSecretName is the name that will be used by default for the
 	// Kubernetes secret containing the Kong enterprise license that will be


### PR DESCRIPTION
Apart from the version bump it fixes the test which now uses a go-kong version of parsing admin api return Kong version.

---

Fixes: #438