### PR TITLE
ci: allow making tests workflow green for external contributors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,3 +27,5 @@ jobs:
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3.4.0
+      with:
+        skip-cache: true # actions/setup-go from v4 handles caching for us

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,6 +85,12 @@ jobs:
         test: ${{ fromJSON(needs.setup-integration-tests.outputs.test_names) }}
     runs-on: ubuntu-latest
     steps:
+    # This step is needed to avoid running the integration tests if the secrets are not available.
+    # TODO: remove this step once we have a way to run integration tests on forks.
+    # https://github.com/Kong/kubernetes-testing-framework/issues/596
+    - name: Detect if we should run (have required secrets)
+      id: detect_if_should_run
+      run: echo "result=${{ secrets.PULP_PASSWORD != '' }}" >> $GITHUB_OUTPUT
 
     - name: checkout repository
       uses: actions/checkout@v3
@@ -92,16 +98,19 @@ jobs:
         fetch-depth: 0
 
     - uses: Kong/kong-license@master
+      if: steps.detect_if_should_run.outputs.result == 'true'
       id: license
       with:
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: setup golang
+      if: steps.detect_if_should_run.outputs.result == 'true'
       uses: actions/setup-go@v4
       with:
         go-version: '^1.19'
 
     - name: run integration test ${{ matrix.test }}
+      if: steps.detect_if_should_run.outputs.result == 'true'
       run: make test.integration
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,6 +121,7 @@ jobs:
         NCPU: 1
 
     - name: Upload coverage to Codecov
+      if: steps.detect_if_should_run.outputs.result == 'true'
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -132,6 +142,9 @@ jobs:
     environment: gcloud
     runs-on: ubuntu-latest
     steps:
+      # This step is needed to avoid running the e2e tests if the secrets are not available.
+      # TODO: remove this step once we have a way to run integration tests on forks.
+      # https://github.com/Kong/kubernetes-testing-framework/issues/596
       - name: Detect if we should run (have required secrets)
         id: detect_if_should_run
         run: echo "result=${{ secrets.PULP_PASSWORD != '' && secrets.GOOGLE_APPLICATION_CREDENTIALS != '' }}" >> $GITHUB_OUTPUT

--- a/pkg/clusters/addons/certmanager/addon.go
+++ b/pkg/clusters/addons/certmanager/addon.go
@@ -185,7 +185,7 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	return nil, true, nil
 }
 
-func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/addons/httpbin/addon.go
+++ b/pkg/clusters/addons/httpbin/addon.go
@@ -155,7 +155,7 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 	return utils.IsNamespaceAvailable(ctx, cluster, a.namespace)
 }
 
-func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/addons/istio/addon.go
+++ b/pkg/clusters/addons/istio/addon.go
@@ -207,7 +207,7 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 	return utils.IsNamespaceAvailable(ctx, cluster, Namespace)
 }
 
-func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/addons/knative/knative.go
+++ b/pkg/clusters/addons/knative/knative.go
@@ -88,7 +88,7 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	return nil, true, nil
 }
 
-func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -173,7 +173,7 @@ func (a *Addon) Name() clusters.AddonName {
 	return AddonName
 }
 
-func (a *Addon) Dependencies(ctx context.Context, cluster clusters.Cluster) []clusters.AddonName {
+func (a *Addon) Dependencies(_ context.Context, cluster clusters.Cluster) []clusters.AddonName {
 	if _, ok := cluster.(*kind.Cluster); ok {
 		if a.proxyAdminServiceTypeLoadBalancer {
 			return []clusters.AddonName{
@@ -361,7 +361,7 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 
 	// delete the chart release from the cluster
 	stderr := new(bytes.Buffer)
-	cmd := exec.Command("helm", "--kubeconfig", kubeconfig.Name(), "uninstall", DefaultDeploymentName, "--namespace", a.namespace) //nolint:gosec
+	cmd := exec.CommandContext(ctx, "helm", "--kubeconfig", kubeconfig.Name(), "uninstall", DefaultDeploymentName, "--namespace", a.namespace) //nolint:gosec
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -181,7 +181,7 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 
 	// delete the chart release from the cluster
 	stderr := new(bytes.Buffer)
-	cmd := exec.Command("helm", "--kubeconfig", kubeconfig.Name(), "uninstall", DefaultReleaseName, "--namespace", Namespace) //nolint:gosec
+	cmd := exec.CommandContext(ctx, "helm", "--kubeconfig", kubeconfig.Name(), "uninstall", DefaultReleaseName, "--namespace", Namespace) //nolint:gosec
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
@@ -195,7 +195,7 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 	return utils.IsNamespaceAvailable(ctx, cluster, Namespace)
 }
 
-func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/addons/loadimage/addon.go
+++ b/pkg/clusters/addons/loadimage/addon.go
@@ -43,7 +43,7 @@ func (a *Addon) Dependencies(_ context.Context, _ clusters.Cluster) []clusters.A
 func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	switch ctype := cluster.Type(); ctype {
 	case kind.KindClusterType:
-		if err := a.loadIntoKind(cluster); err != nil {
+		if err := a.loadIntoKind(ctx, cluster); err != nil {
 			return err
 		}
 	default:
@@ -53,7 +53,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	return nil
 }
 
-func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
+func (a *Addon) Delete(_ context.Context, cluster clusters.Cluster) error {
 	switch ctype := cluster.Type(); ctype {
 	case kind.KindClusterType:
 		// per https://github.com/kubernetes-sigs/kind/issues/658 this is basically impossible
@@ -66,12 +66,12 @@ func (a *Addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 	}
 }
 
-func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.Object, bool, error) {
+func (a *Addon) Ready(context.Context, clusters.Cluster) ([]runtime.Object, bool, error) {
 	// no way to verify this, we rely on Deploy's cmd.Run() not failing
 	return nil, a.loaded, nil
 }
 
-func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/addons/loadimage/cluster_implementations.go
+++ b/pkg/clusters/addons/loadimage/cluster_implementations.go
@@ -2,6 +2,7 @@ package loadimage
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
@@ -9,7 +10,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 )
 
-func (a *Addon) loadIntoKind(cluster clusters.Cluster) error {
+func (a *Addon) loadIntoKind(ctx context.Context, cluster clusters.Cluster) error {
 	if len(a.images) == 0 {
 		return fmt.Errorf("no images provided")
 	}
@@ -22,7 +23,7 @@ func (a *Addon) loadIntoKind(cluster clusters.Cluster) error {
 	deployArgs = append(deployArgs, a.images...)
 
 	stderr := new(bytes.Buffer)
-	cmd := exec.Command("kind", deployArgs...)
+	cmd := exec.CommandContext(ctx, "kind", deployArgs...)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -117,7 +117,7 @@ func (a *addon) Delete(ctx context.Context, cluster clusters.Cluster) error {
 
 func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.Object, bool, error) {
 	deployment, err := cluster.Client().AppsV1().Deployments(DefaultNamespace).
-		Get(context.TODO(), "controller", metav1.GetOptions{})
+		Get(ctx, "controller", metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, false, nil
@@ -132,7 +132,7 @@ func (a *addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	return nil, true, nil
 }
 
-func (a *addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/addons/registry/addon.go
+++ b/pkg/clusters/addons/registry/addon.go
@@ -452,7 +452,7 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) (waitForObj
 	return utils.IsNamespaceAvailable(ctx, cluster, Namespace)
 }
 
-func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (map[string][]byte, error) {
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
 	diagnostics := make(map[string][]byte)
 	return diagnostics, nil
 }

--- a/pkg/clusters/cleanup_test.go
+++ b/pkg/clusters/cleanup_test.go
@@ -122,7 +122,7 @@ func TestFixupObjKinds(t *testing.T) {
 	}
 }
 
-func TestCleanerCanBeUsedConcurrently(t *testing.T) {
+func TestCleanerCanBeUsedConcurrently(*testing.T) {
 	cleaner := NewCleaner(nil)
 	for i := 0; i < 100; i++ {
 		i := i

--- a/pkg/clusters/utils.go
+++ b/pkg/clusters/utils.go
@@ -104,7 +104,7 @@ func GetIngressLoadbalancerStatus(ctx context.Context, c Cluster, namespace stri
 // CreateNamespace creates a new namespace in the given cluster provided a name.
 func CreateNamespace(ctx context.Context, cluster Cluster, namespace string) error {
 	nsName := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := cluster.Client().CoreV1().Namespaces().Create(context.Background(), nsName, metav1.CreateOptions{})
+	_, err := cluster.Client().CoreV1().Namespaces().Create(ctx, nsName, metav1.CreateOptions{})
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err


### PR DESCRIPTION
This is a workaround to allow merging changes from external contributors. It will skip integration and e2e tests in case the required secrets are missing. 

I had to fix a couple of new linter issues that somehow started to pop up now. 

Instead of this workaround, we'll need to make the workflow runnable after some verification steps for any PR. An issue to track this effort: https://github.com/Kong/kubernetes-testing-framework/issues/596