### PR TITLE
test: skip cases requiring license in integration tests and update GH workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -96,9 +96,14 @@ jobs:
     steps:
     # This step is needed to avoid running the integration tests requiring an enterprise license
     # if the secrets are not available.
-    - name: Detect if we should run and set env to enable tests requring a license (have required secrets)
+    - name: Detect if we should run test cases requring an enterprise license (have required secrets)
       id: detect_if_should_run_enterprise
-      run: echo "result=${{ secrets.PULP_PASSWORD != '' }}" >> $GITHUB_OUTPUT && echo "KTF_TEST_RUN_ENTERPRISE_CASES=true" >> $GITHUB_ENV
+      run: echo "result=${{ secrets.PULP_PASSWORD != '' }}" >> $GITHUB_OUTPUT
+
+    - name: Set environment variable to enable test cases requiring an enterprise license
+      if: steps.detect_if_should_run_enterprise.outputs.result == 'true'
+      id: set_run_enterprise_env
+      run: echo "KTF_TEST_RUN_ENTERPRISE_CASES=true" >> $GITHUB_ENV
 
     - name: checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -94,12 +94,11 @@ jobs:
         test: ${{ fromJSON(needs.setup-integration-tests.outputs.test_names) }}
     runs-on: ubuntu-latest
     steps:
-    # This step is needed to avoid running the integration tests if the secrets are not available.
-    # TODO: remove this step once we have a way to run integration tests on forks.
-    # https://github.com/Kong/kubernetes-testing-framework/issues/596
-    - name: Detect if we should run (have required secrets)
-      id: detect_if_should_run
-      run: echo "result=${{ secrets.PULP_PASSWORD != '' }}" >> $GITHUB_OUTPUT
+    # This step is needed to avoid running the integration tests requiring an enterprise license
+    # if the secrets are not available.
+    - name: Detect if we should run and set env to enable tests requring a license (have required secrets)
+      id: detect_if_should_run_enterprise
+      run: echo "result=${{ secrets.PULP_PASSWORD != '' }}" >> $GITHUB_OUTPUT && echo "KTF_TEST_RUN_ENTERPRISE_CASES=true" >> $GITHUB_ENV
 
     - name: checkout repository
       uses: actions/checkout@v3
@@ -107,19 +106,17 @@ jobs:
         fetch-depth: 0
 
     - uses: Kong/kong-license@master
-      if: steps.detect_if_should_run.outputs.result == 'true'
+      if: steps.detect_if_should_run_enterprise.outputs.result == 'true'
       id: license
       with:
         password: ${{ secrets.PULP_PASSWORD }}
 
     - name: setup golang
-      if: steps.detect_if_should_run.outputs.result == 'true'
       uses: actions/setup-go@v4
       with:
         go-version: '^1.19'
 
     - name: run integration test ${{ matrix.test }}
-      if: steps.detect_if_should_run.outputs.result == 'true'
       run: make test.integration
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -134,7 +131,6 @@ jobs:
     # somewhat defeats the purpose of uploading those reports. Why bother uploading
     # if we don't care if the upload's successful?
     - name: Upload coverage to Codecov
-      if: steps.detect_if_should_run.outputs.result == 'true'
       uses: Wandalen/wretry.action@v1.0.36
       with:
         action: codecov/codecov-action@v3

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 func TestKongEnterprisePostgres(t *testing.T) {
-	t.Parallel()
 	SkipEnterpriseTestIfNoEnv(t)
+	t.Parallel()
 
 	t.Log("preparing kong enterprise secrets")
 	licenseJSON, err := kong.GetLicenseJSONFromEnv()

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestKongEnterprisePostgres(t *testing.T) {
 	t.Parallel()
+	SkipEnterpriseTestIfNoEnv(t)
 
 	t.Log("preparing kong enterprise secrets")
 	licenseJSON, err := kong.GetLicenseJSONFromEnv()

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -5,6 +5,8 @@ package integration
 
 import (
 	"context"
+	"os"
+	"testing"
 )
 
 // -----------------------------------------------------------------------------
@@ -15,3 +17,12 @@ var (
 	// ctx is a common context that can be used between tests
 	ctx = context.Background()
 )
+
+// SkipEnterpriseTestIfNoEnv skips test cases that requires an enterprise license
+// if environment variable KTF_TEST_RUN_ENTERPRISE_CASES is not set.
+// The function should be called at the beginning of test cases requiring an enterprise license.
+func SkipEnterpriseTestIfNoEnv(t *testing.T) {
+	if os.Getenv("KTF_TEST_RUN_ENTERPRISE_CASES") != "true" {
+		t.Skip("skipped the test requiring kong enterprise license")
+	}
+}


### PR DESCRIPTION
partial of #596, enable forks to run integration tests not requiring an enterprise license.
Note: This PR is used to test the effect of running integration tests on forks.