### PR TITLE
feat(k8s): Switch from CoreV1 Endpoints to DiscoveryV1 EndpointSlice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.31.0
+
+- Convert dumpDiag to use kind export logs
+  [#591](https://github.com/Kong/kubernetes-testing-framework/pull/591)
+- Switch from `CoreV1 Endpoints` to `DiscoveryV1 EndpointSlice`
+  [#643](https://github.com/Kong/kubernetes-testing-framework/pull/643)
+
 ## v0.30.1
 
 - Upgrade `metallb` addon to `v0.13.9`


### PR DESCRIPTION
EndpointSlice API is available as V1 since K8s 1.21. Let's do not rely on old Endpoint API in KTF.

It's been spotted during work on https://github.com/Kong/kubernetes-ingress-controller/issues/3916.
[`TestValidationWebhook`](https://github.com/Kong/kubernetes-ingress-controller/blob/aad1dbb1513dd49a14db0f3dc8b6ad4158c2a292/test/integration/webhook_test.go#LL43C6-L43C27) from KIC [uses `WaitForConnectionOnServicePort` function](https://github.com/Kong/kubernetes-ingress-controller/blob/aad1dbb1513dd49a14db0f3dc8b6ad4158c2a292/test/integration/webhook_test.go#L682) from KTF. When KIC drops `Endpoints` in favour of `EndpointSlice` this test doesn't pass, because `Endpoints` are not created (and KTF expecting them).

Mirroring works in other way from `Endpoints` to `EndpointSlices` [under circumstances described in docs](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/#endpointslice-mirroring). Thus after this change KTF should be still backward compatible with `Endpoints` and does not break someone's tests that rely on old `Endpoints`.

I've tested this change with KIC and everything passes
- KIC with old `Endpoints` and KTF with `EndpointSlice`
- KIC with `EndpointSlice` (WIP) and KTF with `EndpointSlice`

Thus this PR with high certainty (maybe some edge cases exist) shouldn't break someone's setup. 

Other improvements - reduce coupling by replacing concrete K8s client as parameter with corresponding interface. 
