### PR TITLE
chore(ci): introduce importas and forbidigo to golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ linters:
   - errcheck
   - exhaustive
   - exportloopref
+  - forbidigo
   - gochecknoinits
   - gofmt
   - goimports
@@ -52,6 +53,32 @@ linters-settings:
       - gopkg.in/yaml.v3:
           recommendations:
           - sigs.k8s.io/yaml
+  importas:
+    no-unaliased: true
+    alias:
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/api/apps/v1
+        alias: appsv1
+      - pkg: k8s.io/api/networking/v1
+        alias: netv1
+      - pkg: k8s.io/api/networking/v1beta1
+        alias: netv1beta1
+      - pkg: k8s.io/api/discovery/v1
+        alias: discoveryv1
+      - pkg: k8s.io/api/extensions/v1beta1
+        alias: extv1beta1
+      - pkg: k8s.io/api/rbac/v1
+        alias: rbacv1
 
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
+        alias: gateway${1}
+  forbidigo:
+    exclude_godoc_examples: false
+    forbid:
+      - 'CoreV1\(\)\.Endpoints(# use DiscoveryV1 EndpointSlices API instead)?'
+      - 'corev1\.Endpoint(# use DiscoveryV1 EndpointSlices API instead)?'
 issues:
   fix: true

--- a/pkg/clusters/cleanup_test.go
+++ b/pkg/clusters/cleanup_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -127,13 +127,13 @@ func TestCleanerCanBeUsedConcurrently(*testing.T) {
 	for i := 0; i < 100; i++ {
 		i := i
 		go func() {
-			cleaner.Add(&v1.Pod{})
+			cleaner.Add(&corev1.Pod{})
 		}()
 		go func() {
 			cleaner.AddManifest(fmt.Sprintf("manifest-%d.yaml", i))
 		}()
 		go func() {
-			cleaner.AddNamespace(&v1.Namespace{
+			cleaner.AddNamespace(&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("ns-%d", i),
 				},


### PR DESCRIPTION
Configure new linters in `golangci-lint`
- [forbidgo](https://golangci-lint.run/usage/linters/#forbidigo) to prevent using old CoreV1 Endpoints API
- [importas](https://golangci-lint.run/usage/linters/#importas) ensure that `k8s.io/*` packages are imported with standardised aliases (used in other Kong projects e.g. KIC)