### PR TITLE
chore(tests): add integration test for function WaitForConnectionOnServicePort

### DIFF
--- a/pkg/utils/kubernetes/networking/services.go
+++ b/pkg/utils/kubernetes/networking/services.go
@@ -140,10 +140,10 @@ func WaitForConnectionOnServicePort(ctx context.Context, c kubernetes.Interface,
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("context completed while waiting for %s:%d to be connected", ip, port)
+			return fmt.Errorf("context completed or dialTimeout reached while waiting for %s:%d to be connected", ip, port)
 		case <-ticker.C:
 			dialer := &net.Dialer{Timeout: dialTimeout}
-			if _, err := dialer.Dial("tcp", address); err == nil {
+			if _, err := dialer.DialContext(ctx, "tcp", address); err == nil {
 				return nil
 			}
 		}

--- a/test/integration/utils_k8s_networking_test.go
+++ b/test/integration/utils_k8s_networking_test.go
@@ -1,0 +1,41 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metallbaddon "github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/metallb"
+	"github.com/kong/kubernetes-testing-framework/pkg/environments"
+	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/networking"
+)
+
+func TestWaitForConnectionOnServicePort(t *testing.T) {
+	t.Parallel()
+
+	t.Log("creating a test environment with MetalLB to test helper function WaitForConnectionOnServicePort")
+	env, err := environments.NewBuilder().WithAddons(metallbaddon.New()).Build(ctx)
+	require.NoError(t, err)
+
+	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())
+	defer func() {
+		t.Logf("cleaning up environment %s and cluster %s", env.Name(), env.Cluster().Name())
+		require.NoError(t, env.Cleanup(ctx))
+	}()
+
+	t.Log("waiting for the test environment to be ready")
+	require.NoError(t, <-env.WaitForReady(ctx))
+
+	t.Log("verifying that addon - MetalLB has been loaded into the environment")
+	require.Len(t, env.Cluster().ListAddons(), 1)
+
+	t.Logf("verifying that helper function WaitForConnectionOnServicePort can make a successful TCP connection to existing K8s service")
+	// It's safe to assume that kube-dns service will be available in any K8s cluster.
+	// It can be used for this test, because it supports DNS over TCP too.
+	conErr := networking.WaitForConnectionOnServicePort(ctx, env.Cluster().Client(), "kube-system", "kube-dns", 53, 5*time.Second)
+	require.NoError(t, conErr)
+}


### PR DESCRIPTION
Closes #649 

PR introduces integration test for `WaitForConnectionOnServicePort` it depends on `WaitForServiceLoadBalancerAddress` which is also used in https://github.com/Kong/kubernetes-testing-framework/blob/b3347364485f45c24df0852a41ae83e68959aa08/pkg/clusters/addons/registry/addon.go#L234 (furthermore registry is covered by the test in [test/integration/registry_test.go](https://github.com/Kong/kubernetes-testing-framework/blob/26cb5599358a414da86d7af003ef3b4eed251d17/test/integration/registry_test.go)) too. So now both functions are tested. 