### PR TITLE
feat(kind): allow passing config for Kind clusters with io.Reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.33.0
+
+- Allow passing config for Kind clusters with io.Reader - introduce method
+  `WithConfigReader(cfg io.Reader)`
+  [#683](https://github.com/Kong/kubernetes-testing-framework/pull/683)
+
 ## v0.32.0
 
 - Migrate from github.com/jetstack/cert-manager to github.com/cert-manager/cert-manager

--- a/pkg/clusters/types/kind/builder.go
+++ b/pkg/clusters/types/kind/builder.go
@@ -50,7 +50,7 @@ func (b *Builder) WithClusterVersion(version semver.Version) *Builder {
 
 // WithConfig sets a filename containing a KIND config
 // See: https://kind.sigs.k8s.io/docs/user/configuration
-// This will override any config set previously with WithConfigReader.
+// This will override any config set previously.
 func (b *Builder) WithConfig(filename string) *Builder {
 	b.configPath = &filename
 	b.configReader = nil
@@ -59,7 +59,7 @@ func (b *Builder) WithConfig(filename string) *Builder {
 
 // WithConfigReader sets a reader containing a KIND config
 // See: https://kind.sigs.k8s.io/docs/user/configuration
-// This will override any config set previously with WithConfig.
+// This will override any config set previously.
 func (b *Builder) WithConfigReader(cfg io.Reader) *Builder {
 	b.configReader = cfg
 	b.configPath = nil

--- a/pkg/clusters/types/kind/builder.go
+++ b/pkg/clusters/types/kind/builder.go
@@ -1,8 +1,11 @@
 package kind
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os/exec"
 	"sync"
 
 	"github.com/blang/semver/v4"
@@ -20,6 +23,7 @@ type Builder struct {
 	addons         clusters.Addons
 	clusterVersion *semver.Version
 	configPath     *string
+	configReader   io.Reader
 	calicoCNI      bool
 }
 
@@ -45,9 +49,20 @@ func (b *Builder) WithClusterVersion(version semver.Version) *Builder {
 }
 
 // WithConfig sets a filename containing a KIND config
-// See: https://kind.sigs.k8s.io/docs/user/configuration/
+// See: https://kind.sigs.k8s.io/docs/user/configuration
+// This will override any config set previously with WithConfigReader.
 func (b *Builder) WithConfig(filename string) *Builder {
 	b.configPath = &filename
+	b.configReader = nil
+	return b
+}
+
+// WithConfigReader sets a reader containing a KIND config
+// See: https://kind.sigs.k8s.io/docs/user/configuration
+// This will override any config set previously with WithConfig.
+func (b *Builder) WithConfigReader(cfg io.Reader) *Builder {
+	b.configReader = cfg
+	b.configPath = nil
 	return b
 }
 
@@ -77,12 +92,23 @@ func (b *Builder) Build(ctx context.Context) (clusters.Cluster, error) {
 		deployArgs = append(deployArgs, "--wait", "1s")
 	}
 
+	var stdin io.Reader
 	if b.configPath != nil {
 		deployArgs = append(deployArgs, "--config", *b.configPath)
+	} else if b.configReader != nil {
+		deployArgs = append(deployArgs, "--config", "-")
+		stdin = b.configReader
 	}
 
-	if err := createCluster(ctx, b.Name, deployArgs...); err != nil {
-		return nil, fmt.Errorf("failed to create cluster %s: %w", b.Name, err)
+	args := append([]string{"create", "cluster", "--name", b.Name}, deployArgs...)
+	stderr := new(bytes.Buffer)
+	cmd := exec.CommandContext(ctx, "kind", args...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+	cmd.Stdin = stdin
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to create cluster %s: %s: %w", b.Name, stderr.String(), err)
 	}
 
 	cfg, kc, err := clientForCluster(b.Name)

--- a/pkg/clusters/types/kind/utils.go
+++ b/pkg/clusters/types/kind/utils.go
@@ -49,21 +49,6 @@ const (
 // Private Functions - Cluster Management
 // -----------------------------------------------------------------------------
 
-// createCluster creates a new cluster using Kubernetes in Docker (KIND).
-func createCluster(ctx context.Context, name string, extraArgs ...string) error {
-	args := []string{"create", "cluster", "--name", name}
-	args = append(args, extraArgs...)
-
-	stderr := new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, "kind", args...)
-	cmd.Stdout = io.Discard
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s: %w", stderr.String(), err)
-	}
-	return nil
-}
-
 // deleteKindCluster deletes an existing KIND cluster.
 func deleteKindCluster(ctx context.Context, name string) error {
 	stderr := new(bytes.Buffer)


### PR DESCRIPTION
Passing config to Kind cluster with file path is tedious and inconvenient. Add method  `WithConfigReader(cfg io.Reader)` to Kind builder to allow passing arbitrary YAML without requiring having a concrete file for it.