### PR TITLE
chore(ci): disable depguard linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - depguard
   - dogsled
   - durationcheck
   - errcheck


### PR DESCRIPTION
Since we do not customise config of [depguard](https://github.com/OpenPeeDeeP/depguard), let's disable it as advised in https://github.com/Kong/kubernetes-testing-framework/pull/693#issuecomment-1573662370. It unblocks PRs:
- https://github.com/Kong/kubernetes-testing-framework/pull/693
- https://github.com/Kong/kubernetes-testing-framework/pull/694
- https://github.com/Kong/kubernetes-testing-framework/pull/695