### PR TITLE
ci: fix integration tests aggregate check

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -150,7 +150,7 @@ jobs:
 
   integration-tests-passed:
     needs: integration-tests
-    if: ${{ always() }}
+    if: always() && !contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
     - name: integrations tests pased


### PR DESCRIPTION
The existing `integration-tests-passed` condition passes even when some of the integration tests failed, e.g. https://github.com/Kong/kubernetes-testing-framework/actions/runs/5241672836/jobs/9464102490?pr=703.

This PR tries to address this.