### PR TITLE
ci: use separate CI jobs for e2e tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -156,7 +156,32 @@ jobs:
     - name: integrations tests pased
       run: echo all integrations tests passed
 
+  setup-e2e-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      test_names: ${{ steps.set_test_names.outputs.test_names }}
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - id: set_test_names
+      name: Set test names
+      working-directory: test/e2e/
+      # grep magic described in https://unix.stackexchange.com/a/13472
+      # sed to add the extra $ is because some of our test names overlap. we need it so the -run regex only matches one test
+      run: |
+        echo "test_names=$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | sed -e "s/$/\$/"| jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+
+    - name: Print test names
+      run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
+
   e2e-tests:
+    needs:
+    - setup-e2e-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.setup-e2e-tests.outputs.test_names) }}
     environment: gcloud
     runs-on: ubuntu-latest
     steps:
@@ -189,8 +214,17 @@ jobs:
         if: steps.detect_if_should_run.outputs.result == 'true'
         run: make test.e2e
         env:
+          TEST_RUN: ${{ matrix.test }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+
+  e2e-tests-passed:
+    needs: e2e-tests
+    if: always() && !contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+    - name: e2e tests pased
+      run: echo all e2e tests passed

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,9 @@ test.integration:
 
 .PHONY: test.e2e
 test.e2e:
-	@GOFLAGS="-tags=e2e_tests" go test -timeout 45m -race -v ./test/e2e/...
+	@GOFLAGS="-tags=e2e_tests" go test \
+		-timeout 45m \
+		-run $(TEST_RUN) \
+		-race \
+		-v \
+		./test/e2e/...

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -35,14 +35,12 @@ var (
 	gkeLocation = os.Getenv(gke.GKELocationVar)
 )
 
-func TestGKECluster(t *testing.T) {
-	t.Run("create subnet", func(t *testing.T) {
-		testGKECluster(t, true)
-	})
+func TestGKECluster_create_subnet(t *testing.T) {
+	testGKECluster(t, true)
+}
 
-	t.Run("use default subnet", func(t *testing.T) {
-		testGKECluster(t, false)
-	})
+func TestGKECluster_default_subnet(t *testing.T) {
+	testGKECluster(t, false)
 }
 
 func testGKECluster(t *testing.T, createSubnet bool) {
@@ -64,7 +62,7 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 	t.Logf("configuring the GKE cluster PROJECT=(%s) LOCATION=(%s)", gkeProject, gkeLocation)
 	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation)
 	builder.WithClusterMinorVersion(1, 23)
-	builder.WithWaitForTeardown(true)
+	builder.WithWaitForTeardown(false)
 	builder.WithCreateSubnet(createSubnet)
 	builder.WithLabels(map[string]string{"test-cluster": "true"})
 


### PR DESCRIPTION
This PR makes the e2e tests to run in separate jobs, this making the CI faster by parallelizing the tests.

Similar approach has already been done for integration tests: https://github.com/Kong/kubernetes-testing-framework/blob/cb3a483e674ad2305b21de77d731d7a9a8b92b8b/.github/workflows/tests.yaml#L69-L86