### PR TITLE
chore(build): get rid of obsolete Go build tags

### DIFF
--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -1,5 +1,4 @@
 //go:build e2e_tests
-// +build e2e_tests
 
 package integration
 

--- a/test/integration/calico_test.go
+++ b/test/integration/calico_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/certmanager_test.go
+++ b/test/integration/certmanager_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/cleaner_test.go
+++ b/test/integration/cleaner_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/clusterutils_test.go
+++ b/test/integration/clusterutils_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/istio_test.go
+++ b/test/integration/istio_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/kind_cluster_test.go
+++ b/test/integration/kind_cluster_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/kind_diagnostics_test.go
+++ b/test/integration/kind_diagnostics_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/kind_version_test.go
+++ b/test/integration/kind_version_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/knative_test.go
+++ b/test/integration/knative_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/kuma_test.go
+++ b/test/integration/kuma_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/metallb_test.go
+++ b/test/integration/metallb_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/postgres_test.go
+++ b/test/integration/postgres_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/registry_test.go
+++ b/test/integration/registry_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 

--- a/test/integration/utils_k8s_networking_test.go
+++ b/test/integration/utils_k8s_networking_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package integration
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

Since Go 1.18 the new directive `//go:build` is now preferred and the toolchain will actively remove old directives; as mentioned in Go 1.18 release notes:

> In Go 1.18, go fix now removes the now-obsolete // +build lines in modules declaring go 1.18 or later in their go.mod files.

KIC  specifies in `go.mod` Go version `1.20`.
 
<!-- Please describe why this particular PR is necessary or why you see it as a nice addition -->

**Which issue this PR fixes**:

It's part of the https://github.com/Kong/team-k8s/issues/286
