### PR TITLE
feat: dump diagnostics if cluster not ready

### DIFF
--- a/pkg/clusters/diagnostics.go
+++ b/pkg/clusters/diagnostics.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 )
 
+// DiagnosticOutDirectoryPrefix is the tmpdir prefix used for diagnostic dumps.
+const DiagnosticOutDirectoryPrefix = "ktf-diag-"
+
 // DumpAllDescribeAll gathers diagnostic information from the cluster.
 // Specifically it runs "kubectl get all" and "kubectl describe all" for
 // all resources and stores the output into two respective yaml files

--- a/pkg/clusters/types/gke/cluster.go
+++ b/pkg/clusters/types/gke/cluster.go
@@ -230,7 +230,7 @@ func (c *Cluster) DumpDiagnostics(ctx context.Context, meta string) (string, err
 	defer os.Remove(kubeconfig.Name())
 
 	// create a tempdir
-	outDir, err := os.MkdirTemp(os.TempDir(), "ktf-diag-")
+	outDir, err := os.MkdirTemp(os.TempDir(), clusters.DiagnosticOutDirectoryPrefix)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/clusters/types/kind/cluster.go
+++ b/pkg/clusters/types/kind/cluster.go
@@ -145,7 +145,7 @@ func (c *Cluster) DeleteAddon(ctx context.Context, addon clusters.Addon) error {
 // It returns the path to directory containing all the diagnostic files and an error.
 func (c *Cluster) DumpDiagnostics(ctx context.Context, meta string) (string, error) {
 	// create a tempdir
-	outDir, err := os.MkdirTemp(os.TempDir(), "ktf-diag-")
+	outDir, err := os.MkdirTemp(os.TempDir(), clusters.DiagnosticOutDirectoryPrefix)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/environments/implementation.go
+++ b/pkg/environments/implementation.go
@@ -16,7 +16,11 @@ import (
 // Test Environment - Implementation
 // -----------------------------------------------------------------------------
 
-const objectWaitSleepTime = time.Millisecond * 200
+const (
+	objectWaitSleepTime = time.Millisecond * 200
+
+	readyHungDuration = time.Minute * 20
+)
 
 // environment is the default KTF Environment used for testing Kubernetes ingress.
 type environment struct {
@@ -81,11 +85,22 @@ func (env *environment) WaitForReady(ctx context.Context) chan error {
 	errs := make(chan error)
 
 	go func() {
+		// if the cluster fails to become ready after N minutes, assume it's likely stuck and dump a diagnostic bundle.
+		// this uses its own timer since we can't catch "go test" timeouts via the ctx.
+		hung := time.AfterFunc(readyHungDuration, func() {
+			loc, err := env.Cluster().DumpDiagnostics(ctx, "WaitForReady")
+			if err != nil {
+				errs <- err
+				return
+			}
+			fmt.Printf("cluster not ready after %s, dumped diag to %s\n", readyHungDuration.String(), loc)
+		})
 		waitForObjects := make([]runtime.Object, 0)
 		for {
 			select {
 			case <-ctx.Done():
 				errs <- fmt.Errorf("context done before environment was ready (remaining objects %+v): %w", waitForObjects, ctx.Err())
+				hung.Stop()
 				return
 			default:
 				var ready bool
@@ -97,6 +112,7 @@ func (env *environment) WaitForReady(ctx context.Context) chan error {
 				}
 				if ready {
 					errs <- nil
+					hung.Stop()
 					return
 				}
 				time.Sleep(objectWaitSleepTime)


### PR DESCRIPTION
If the cluster fails to become ready after 20 minutes, assume it's stuck and dump a diagnostic.

At present unready clusters will just hit the test timeout and exit without providing any useful information.