### PR TITLE
refactor: introduce reusable test helpers

### DIFF
--- a/internal/test/assert.go
+++ b/internal/test/assert.go
@@ -4,56 +4,102 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	gokong "github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/require"
 )
 
-type httpResponseOption struct {
-	bodyChecker       func(*testing.T, []byte) bool
-	statusCodeChecker func(t *testing.T, reqURL string, statusCode int, body []byte) bool
+type configurationOption struct {
+	responseChecker []func(*testing.T, *http.Response) bool
+	waitFor         time.Duration
+	interval        time.Duration
 }
 
-type HTTPResponseOpt func(*httpResponseOption)
+type ConfigurationOpt func(*configurationOption)
 
-func WithBodyChecker(bodyChecker func(*testing.T, []byte) bool) HTTPResponseOpt {
-	return func(opts *httpResponseOption) {
-		opts.bodyChecker = bodyChecker
+func WithWaitFor(waitFor time.Duration) ConfigurationOpt {
+	return func(opts *configurationOption) {
+		opts.waitFor = waitFor
 	}
 }
 
-func WithBodyContains(expected string) HTTPResponseOpt {
-	return func(opts *httpResponseOption) {
-		opts.bodyChecker = func(t *testing.T, body []byte) bool {
-			t.Logf("check expected content %s of the response body", expected)
-			return bytes.Contains(body, []byte(expected))
-		}
+func WithInterval(interval time.Duration) ConfigurationOpt {
+	return func(opts *configurationOption) {
+		opts.interval = interval
 	}
 }
 
-func WithStatusCode(expected int) HTTPResponseOpt {
-	return func(opts *httpResponseOption) {
-		opts.statusCodeChecker = func(t *testing.T, reqURL string, statusCode int, body []byte) bool {
-			if statusCode != expected {
-				t.Logf("WARNING: unexpected response %s: %d with body: %s", reqURL, statusCode, body)
+func WithResponseChecker(bodyChecker func(*testing.T, *http.Response) bool) ConfigurationOpt {
+	return func(opts *configurationOption) {
+		opts.responseChecker = append(opts.responseChecker, bodyChecker)
+	}
+}
+
+func WithBodyContains(expected string) ConfigurationOpt {
+	return WithResponseChecker(
+		func(t *testing.T, resp *http.Response) bool {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Logf("WARNING: error cannot read response body %s: %v", resp.Request.URL, err)
 				return false
 			}
-			t.Logf("expected status code %d of the response received", statusCode)
+			if !bytes.Contains(body, []byte(expected)) {
+				t.Logf("WARNING: unexpected content of response body %s: %s", resp.Request.URL, body)
+				return false
+			}
+			t.Logf("expected content of the response body received")
 			return true
-		}
-	}
+		},
+	)
 }
 
-// EventuallyExpectedStatusCodeAndBody is a helper function that retries the request until
+func WithStatusCode(expected int) ConfigurationOpt {
+	return WithResponseChecker(
+		func(t *testing.T, resp *http.Response) bool {
+			if resp.StatusCode != expected {
+				t.Logf("WARNING: unexpected status code %d, expected %d", resp.StatusCode, expected)
+				return false
+			}
+			t.Logf("expected status code received")
+			return true
+		},
+	)
+}
+
+func WithEnterpriseHeader() ConfigurationOpt {
+	return WithResponseChecker(
+		func(t *testing.T, resp *http.Response) bool {
+			version, _ := strings.CutPrefix(resp.Header.Get("Server"), "kong/")
+			v, err := gokong.NewVersion(version)
+			if err != nil {
+				t.Logf("WARNING: error while parsing admin api version %s: %v", version, err)
+				return false
+			}
+			t.Logf("admin api version %s", v)
+			if !v.IsKongGatewayEnterprise() {
+				t.Logf("WARNING: version %s should be an enterprise version but wasn't", v)
+				return false
+			}
+			return true
+		},
+	)
+}
+
+// EventuallyExpectedResponse is a helper function that retries the request until
 // it gets the expected response. For setting expected status code use WithStatusCode
-// option (otherwise it's not checked). For checking content of body use WithBodyContains or
-// WithBodyChecker (for fine-grained control), only one should be passed.
+// option (otherwise it's not checked). For checking content of body only one has to be
+// passed (body can be read only one time).
 // Default is to retry for 1 minute with 1 second interval.
-func EventuallyExpectedStatusCodeAndBody(
-	t *testing.T, httpClient *http.Client, req *http.Request, opts ...HTTPResponseOpt,
+func EventuallyExpectedResponse(
+	t *testing.T, httpClient *http.Client, req *http.Request, opts ...ConfigurationOpt,
 ) {
-	var options httpResponseOption
+	options := configurationOption{
+		waitFor:  time.Minute,
+		interval: time.Second,
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(&options)
@@ -68,22 +114,17 @@ func EventuallyExpectedStatusCodeAndBody(
 				return false
 			}
 			defer resp.Body.Close()
-			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Logf("WARNING: error cannot read response body %s: %v", req.URL, err)
 				return false
 			}
-			if options.statusCodeChecker != nil && !options.statusCodeChecker(t, req.URL.String(), resp.StatusCode, body) {
-				return false
-			} else {
-				t.Log("skipping checking status code of the response")
-			}
-			if options.bodyChecker != nil && !options.bodyChecker(t, body) {
-				t.Logf("WARNING: unexpected content of response body %s: %s", req.URL, body)
-				return false
+			for _, checker := range options.responseChecker {
+				if !checker(t, resp) {
+					return false
+				}
 			}
 			return true
 		},
-		time.Minute, time.Second,
+		options.waitFor, options.interval,
 	)
 }

--- a/internal/test/assert.go
+++ b/internal/test/assert.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type checkerOptions struct {
+	bodyChecker func(*testing.T, []byte) bool
+}
+
+type CheckerOption func(*checkerOptions)
+
+func WithBodyChecker(bodyChecker func(*testing.T, []byte) bool) CheckerOption {
+	return func(opts *checkerOptions) {
+		opts.bodyChecker = bodyChecker
+	}
+}
+
+// EventuallyExpectedStatusCodeAndBody is a helper function that retries the request until
+// it gets the expected status. It also checks the body of the response if a body checker
+// is provided. Default is to retry for 1 minute with 1 second interval.
+func EventuallyExpectedStatusCodeAndBody(
+	t *testing.T, httpClient *http.Client, req *http.Request, expectedStatusCode int, opts ...CheckerOption,
+) {
+	var options checkerOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	require.Eventually(
+		t,
+		func() bool {
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				t.Logf("WARNING: error while waiting for %s: %v", req.URL, err)
+				return false
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Logf("WARNING: error cannot read response body %s: %v", req.URL, err)
+				return false
+			}
+			if resp.StatusCode != expectedStatusCode {
+				t.Logf("WARNING: unexpected response %s: %s with body: %s", req.URL, resp.Status, body)
+				return false
+			}
+			if options.bodyChecker != nil && !options.bodyChecker(t, body) {
+				t.Logf("WARNING: unexpected content of response body %s: %s", req.URL, body)
+				return false
+			}
+			return true
+		},
+		time.Minute, time.Second,
+	)
+}

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -79,7 +79,7 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 	}
 	t.Log("verifying the admin api version is enterprise")
 	httpClient := &http.Client{Timeout: time.Second * 10}
-	test.EventuallyExpectedResponse(t, httpClient, req, test.WithStatusCode(http.StatusOK), test.WithEnterpriseHeader())
+	test.EventuallyExpectResponse(t, httpClient, req, test.WithStatusCode(http.StatusOK), test.WithEnterpriseHeader())
 
 	t.Log("deploying httpbin and waiting for readiness")
 	httpBinAddon := httpbin.New()
@@ -93,7 +93,7 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 		nil,
 	)
 	require.NoError(t, err)
-	test.EventuallyExpectedResponse(
+	test.EventuallyExpectResponse(
 		t, httpClient, req, test.WithStatusCode(http.StatusOK), test.WithBodyContains("<title>httpbin.org</title>"),
 	)
 
@@ -111,7 +111,7 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 		t.Fatal("not implemented yet")
 	}
 	req.Header.Set("Content-Type", "application/json")
-	test.EventuallyExpectedResponse(t, httpClient, req, test.WithStatusCode(http.StatusCreated))
+	test.EventuallyExpectResponse(t, httpClient, req, test.WithStatusCode(http.StatusCreated))
 
 	t.Log("verifying that the workspace was indeed created")
 	req, err = http.NewRequestWithContext(
@@ -123,7 +123,7 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 	if adminPassword != "" {
 		decorateRequestWithAdminPassword(t, req, adminPassword)
 	}
-	test.EventuallyExpectedResponse(t, httpClient, req, test.WithStatusCode(http.StatusOK))
+	test.EventuallyExpectResponse(t, httpClient, req, test.WithStatusCode(http.StatusOK))
 
 }
 

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -27,31 +27,37 @@ func TestKongEnterprisePostgres(t *testing.T) {
 	SkipEnterpriseTestIfNoEnv(t)
 	t.Parallel()
 
-	t.Log("preparing kong enterprise secrets")
-	licenseJSON, err := kong.GetLicenseJSONFromEnv()
-	require.NoError(t, err)
-	adminPassword, err := password.Generate(10, 5, 0, false, false)
-	require.NoError(t, err)
+	licenseJSON := prepareKongEnterpriseLicense(t)
+
+	t.Logf("generating a random password for the proxy admin service (applies only for dbmode)")
+	adminPassword := password.MustGenerate(10, 5, 0, false, false)
 
 	t.Log("configuring the testing environment")
-	metallbAddon := metallbaddon.New()
 	kongAddon := kongaddon.NewBuilder().
-		WithProxyEnterpriseEnabled(licenseJSON).
-		WithPostgreSQL().
 		WithProxyAdminServiceTypeLoadBalancer().
+		WithPostgreSQL().
+		WithProxyEnterpriseEnabled(licenseJSON).
 		WithProxyEnterpriseSuperAdminPassword(adminPassword).
 		Build()
-	builder := environment.NewBuilder().WithAddons(kongAddon, metallbAddon)
 
+	deployAndTestKongEnterprise(t, kongAddon, adminPassword)
+}
+
+// deployAndTestKongEnterprise deploys a Kong Enterprise cluster and tests it for basic functionality.
+// It works for both DB-less and DB-mode deployments (configuration of kongAddon). For DB-less set adminPassword to "".
+// It verifies that workspace (enterprise feature) can be successfully created.
+func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, adminPassword string) {
+	metallbAddon := metallbaddon.New()
+	builder := environment.NewBuilder().WithAddons(kongAddon, metallbAddon)
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)
 	require.NoError(t, err)
 
 	t.Logf("setting up the environment cleanup for environment %s and cluster %s", env.Name(), env.Cluster().Name())
-	defer func() {
+	t.Cleanup(func() {
 		t.Logf("cleaning up environment %s and cluster %s", env.Name(), env.Cluster().Name())
 		require.NoError(t, env.Cleanup(ctx))
-	}()
+	})
 
 	t.Log("waiting for environment to be ready")
 	require.NoError(t, <-env.WaitForReady(ctx))
@@ -67,77 +73,127 @@ func TestKongEnterprisePostgres(t *testing.T) {
 	require.NotNil(t, adminURL)
 
 	t.Log("building a GET request to gather admin api information")
-	req, err := http.NewRequestWithContext(ctx, "GET", adminURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, adminURL.String(), nil)
 	require.NoError(t, err)
-	req.Header.Set("Kong-Admin-Token", adminPassword)
-
-	t.Run("verifying the admin api version is enterprise", func(t *testing.T) {
-		t.Log("pulling the admin api information")
-		httpc := http.Client{Timeout: time.Second * 10}
-		var body []byte
-		require.Eventually(t, func() bool {
-			resp, err := httpc.Do(req)
-			if err != nil {
-				return false
-			}
-			defer resp.Body.Close()
-			body, err = io.ReadAll(resp.Body)
-			if err != nil {
-				return false
-			}
-			t.Logf("RESPONSE CODE: %d STATUS: %s", resp.StatusCode, resp.Status)
-			return resp.StatusCode == http.StatusOK
-		}, time.Minute, time.Second)
-
+	if adminPassword != "" {
+		decorateRequestWithAdminPassword(t, req, adminPassword)
+	} else {
+		t.Log("skipping setting the admin api password (Kong-Admin-Token header)")
+	}
+	t.Log("verifying the admin api version is enterprise")
+	httpClient := &http.Client{Timeout: time.Second * 10}
+	eventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusOK, func(t *testing.T, body []byte) bool {
+		t.Log("check expected enterprise version")
 		adminOutput := struct {
 			Version string `json:"version"`
 		}{}
-		require.NoError(t, json.Unmarshal(body, &adminOutput))
-		v, err := gokong.NewVersion(adminOutput.Version)
-		require.NoError(t, err)
-
-		t.Logf("admin api version %s", v)
-		require.Truef(t, v.IsKongGatewayEnterprise(), "version %s should be an enterprise version but wasn't", v)
-	})
-
-	t.Log("verifying enterprise workspace API functionality")
-	workspaceEnabledProxyURL := adminURL.String() + "/workspaces"
-	jsonStr := []byte(`{"name": "test-workspace"}`)
-	req, err = http.NewRequest("POST", workspaceEnabledProxyURL, bytes.NewBuffer(jsonStr))
-	require.NoError(t, err)
-	req.Header.Set("kong-admin-token", adminPassword)
-	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: time.Second * 10}
-	require.Eventually(t, func() bool {
-		resp, err := client.Do(req)
-		if err != nil {
+		if err := json.Unmarshal(body, &adminOutput); err != nil {
+			t.Logf("WARNING: error while unmarshalling admin api output %s: %v", body, err)
 			return false
 		}
-		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusCreated
-	}, time.Minute, time.Second)
+		v, err := gokong.NewVersion(adminOutput.Version)
+		if err != nil {
+			t.Logf("WARNING: error while parsing admin api version %s: %v", adminOutput.Version, err)
+			return false
+		}
+		t.Logf("admin api version %s", v)
+		if !v.IsKongGatewayEnterprise() {
+			t.Logf("version %s should be an enterprise version but wasn't", v)
+			return false
+		}
+		return true
+	})
 
 	t.Log("deploying httpbin and waiting for readiness")
-	httpbinAddon := httpbin.New()
-	require.NoError(t, env.Cluster().DeployAddon(ctx, httpbinAddon))
+	httpBinAddon := httpbin.New()
+	require.NoError(t, env.Cluster().DeployAddon(ctx, httpBinAddon))
 	require.NoError(t, <-env.WaitForReady(ctx))
 
 	t.Log("accessing httpbin via ingress to validate that the kong proxy is functioning")
-	httpc := http.Client{Timeout: time.Second * 10}
-	require.Eventually(t, func() bool {
-		resp, err := httpc.Get(fmt.Sprintf("%s/%s", proxyURL, httpbinAddon.Path()))
-		if err != nil {
-			t.Logf("WARNING: error while waiting for %s: %v", proxyURL, err)
-			return false
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			b := new(bytes.Buffer)
-			n, err := b.ReadFrom(resp.Body)
-			require.NoError(t, err)
-			require.True(t, n > 0)
-			return strings.Contains(b.String(), "<title>httpbin.org</title>")
-		}
-		return false
-	}, time.Minute*3, time.Second)
+	req, err = http.NewRequestWithContext(
+		ctx, http.MethodGet,
+		proxyURL.JoinPath(httpBinAddon.Path()).String(),
+		nil,
+	)
+	require.NoError(t, err)
+	eventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusOK, func(t *testing.T, body []byte) bool {
+		const expectedBody = "<title>httpbin.org</title>"
+		t.Logf("check expected content %s of the response body", expectedBody)
+		return bytes.Contains(body, []byte(expectedBody))
+	})
+
+	const workspaceToCreate = "test-workspace"
+	if adminPassword != "" {
+		t.Log("verifying enterprise workspace API functionality using /workspaces (works only for dbmode)")
+		req, err = http.NewRequestWithContext(
+			ctx, http.MethodPost, adminURL.JoinPath("/workspaces").String(),
+			strings.NewReader(fmt.Sprintf(`{"name": "%s"}`, workspaceToCreate)),
+		)
+		require.NoError(t, err)
+		decorateRequestWithAdminPassword(t, req, adminPassword)
+	} else {
+		t.Log("verifying enterprise workspace API functionality using /config (works only for dblessmode)")
+		t.Fatal("not implemented yet")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	eventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusCreated, nil)
+
+	t.Log("verifying that the workspace was indeed created")
+	req, err = http.NewRequestWithContext(
+		ctx, http.MethodGet,
+		adminURL.JoinPath("/workspaces/").JoinPath(workspaceToCreate).String(),
+		nil,
+	)
+	require.NoError(t, err)
+	if adminPassword != "" {
+		decorateRequestWithAdminPassword(t, req, adminPassword)
+	}
+	eventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusOK, nil)
+
+}
+
+func decorateRequestWithAdminPassword(t *testing.T, req *http.Request, adminPassword string) {
+	t.Helper()
+	const passwdHeader = "Kong-Admin-Token"
+	t.Logf("setting the admin api password (Kong-Admin-Token header %s)", passwdHeader)
+	req.Header.Set(passwdHeader, adminPassword)
+}
+
+func prepareKongEnterpriseLicense(t *testing.T) string {
+	t.Helper()
+	t.Log("preparing kong enterprise license")
+	licenseJSON, err := kong.GetLicenseJSONFromEnv()
+	require.NoError(t, err)
+	return licenseJSON
+}
+
+func eventuallyExpectedStatusCodeAndBody(
+	t *testing.T, httpClient *http.Client, req *http.Request, expectedStatusCode int, bodyChecker func(t *testing.T, body []byte) bool,
+) {
+	require.Eventually(
+		t,
+		func() bool {
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				t.Logf("WARNING: error while waiting for %s: %v", req.URL, err)
+				return false
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Logf("WARNING: error cannot read response body %s: %v", req.URL, err)
+				return false
+			}
+			if resp.StatusCode != expectedStatusCode {
+				t.Logf("WARNING: unexpected response %s: %s with body: %s", req.URL, resp.Status, body)
+				return false
+			}
+			if bodyChecker != nil && !bodyChecker(t, body) {
+				t.Logf("WARNING: unexpected content of response body %s: %s", req.URL, body)
+				return false
+			}
+			return true
+		},
+		time.Minute, time.Second,
+	)
 }

--- a/test/integration/enterprise_test.go
+++ b/test/integration/enterprise_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -82,7 +81,7 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 	}
 	t.Log("verifying the admin api version is enterprise")
 	httpClient := &http.Client{Timeout: time.Second * 10}
-	test.EventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusOK, test.WithBodyChecker(
+	test.EventuallyExpectedStatusCodeAndBody(t, httpClient, req, test.WithStatusCode(http.StatusOK), test.WithBodyChecker(
 		func(t *testing.T, body []byte) bool {
 			t.Log("check expected enterprise version")
 			adminOutput := struct {
@@ -118,13 +117,9 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 		nil,
 	)
 	require.NoError(t, err)
-	test.EventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusOK, test.WithBodyChecker(
-		func(t *testing.T, body []byte) bool {
-			const expectedBody = "<title>httpbin.org</title>"
-			t.Logf("check expected content %s of the response body", expectedBody)
-			return bytes.Contains(body, []byte(expectedBody))
-		},
-	))
+	test.EventuallyExpectedStatusCodeAndBody(
+		t, httpClient, req, test.WithStatusCode(http.StatusOK), test.WithBodyContains("<title>httpbin.org</title>"),
+	)
 
 	const workspaceToCreate = "test-workspace"
 	if adminPassword != "" {
@@ -140,7 +135,7 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 		t.Fatal("not implemented yet")
 	}
 	req.Header.Set("Content-Type", "application/json")
-	test.EventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusCreated)
+	test.EventuallyExpectedStatusCodeAndBody(t, httpClient, req, test.WithStatusCode(http.StatusCreated))
 
 	t.Log("verifying that the workspace was indeed created")
 	req, err = http.NewRequestWithContext(
@@ -152,7 +147,7 @@ func deployAndTestKongEnterprise(t *testing.T, kongAddon *kongaddon.Addon, admin
 	if adminPassword != "" {
 		decorateRequestWithAdminPassword(t, req, adminPassword)
 	}
-	test.EventuallyExpectedStatusCodeAndBody(t, httpClient, req, http.StatusOK)
+	test.EventuallyExpectedStatusCodeAndBody(t, httpClient, req, test.WithStatusCode(http.StatusOK))
 
 }
 


### PR DESCRIPTION
Currently, only Kong Enterprise deployed with Postgres is covered with tests. Refactor by extracting common pieces to make it easy to add a new test for DBLess mode.

Moreover, add a check that the workspace (enterprise feature) has been indeed created in a Kong Gateway (checking directly in API since this test checks to create Kong Gateway that runs in enterprise mode.

In the next separate PR support for DBLess will be tested.

