### PR TITLE
support setting namespace in kong addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Support specifying namespace of Kong addon to deploy Kong in certain
+  namespace.
+  [#766](https://github.com/Kong/kubernetes-testing-framework/pull/766)
+
 ## v0.34.0
 
 - Fix KTF to properly deploy Kong Gateway Enterprise in DBLess mode

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -99,6 +99,11 @@ func (b *Builder) Build() *Addon {
 	}
 }
 
+func (b *Builder) WithNamespace(namespace string) *Builder {
+	b.namespace = namespace
+	return b
+}
+
 func (b *Builder) WithProxyImagePullSecret(server, username, password, email string) *Builder {
 	b.proxyPullSecret = pullSecret{
 		Server:   server,
@@ -118,10 +123,6 @@ func (b *Builder) WithControllerDisabled() *Builder {
 	b.ingressControllerDisabled = true
 	return b
 }
-
-// -----------------------------------------------------------------------------
-// Kong Proxy Configuration Options
-// -----------------------------------------------------------------------------
 
 // WithDBLess configures the resulting Addon to deploy a DBLESS proxy backend.
 func (b *Builder) WithDBLess() *Builder {


### PR DESCRIPTION
support to specify namespace of Kong addon to deploy Kong in certain namespace. Fixes #765 