### PR TITLE
fix: set udpProxy.type to proxyServiceType specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Support specifying namespace of Kong addon to deploy Kong in certain
   namespace.
   [#766](https://github.com/Kong/kubernetes-testing-framework/pull/766)
+- Fix setting UDP proxy service type in Kong addon.
+  [#770](https://github.com/Kong/kubernetes-testing-framework/pull/770)
 
 ## v0.34.0
 

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -293,6 +293,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 		return fmt.Errorf("Service type ExternalName is not currently supported")
 	}
 	a.deployArgs = append(a.deployArgs, "--set", fmt.Sprintf("proxy.type=%s", a.proxyServiceType))
+	a.deployArgs = append(a.deployArgs, "--set", fmt.Sprintf("udpProxy.type=%s", a.proxyServiceType))
 
 	// set the proxy log level
 	if len(a.proxyLogLevel) > 0 {

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -156,7 +156,8 @@ func (b *Builder) WithLogLevel(level string) *Builder {
 	return b
 }
 
-// WithProxyServiceType indicates which Service type to use for ingress traffic.
+// WithProxyServiceType indicates which Service type to use for ingress traffic,
+// including tcp proxy and udp proxy services.
 // The default type is LoadBalancer.
 func (b *Builder) WithProxyServiceType(serviceType corev1.ServiceType) *Builder {
 	b.proxyServiceType = serviceType

--- a/test/integration/kongaddon_test.go
+++ b/test/integration/kongaddon_test.go
@@ -48,8 +48,7 @@ func TestKongAddonWithNamespace(t *testing.T) {
 	kong := kongaddon.NewBuilder().WithNamespace(testNS).WithProxyServiceType(corev1.ServiceTypeClusterIP).Build()
 
 	t.Log("configuring the testing environment")
-	metallb := metallbaddon.New()
-	builder := environment.NewBuilder().WithAddons(kong, metallb)
+	builder := environment.NewBuilder().WithAddons(kong)
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)
@@ -58,8 +57,8 @@ func TestKongAddonWithNamespace(t *testing.T) {
 	err = <-env.WaitForReady(ctx)
 	require.NoError(t, err)
 
-	t.Log("verifying that addons (kong and metallb) have been loaded into the environment")
-	require.Len(t, env.Cluster().ListAddons(), 2)
+	t.Log("verifying that kong addon have been loaded into the environment")
+	require.Len(t, env.Cluster().ListAddons(), 1)
 
 	t.Log("verifying that the kong deployment is in the test namespace")
 	deployments := env.Cluster().Client().AppsV1().Deployments(testNS)
@@ -93,14 +92,11 @@ func testKongAddonWithCustomImage(t *testing.T, tc customImageTest) {
 	kong := kongaddon.NewBuilder().
 		WithProxyImage(tc.proxyImageRepo, tc.proxyImageTag).
 		WithControllerImage(tc.controllerImageRepo, tc.controllerImageTag).
+		WithProxyServiceType(corev1.ServiceTypeClusterIP).
 		Build()
 
 	t.Log("configuring the testing environment")
-	// Add metallb to get an IP address for Kong's LoadBalancerservices
-	// TODO: when https://github.com/Kong/kubernetes-testing-framework/issues/540
-	// gets resolved then we can configure service types to be of ClusterIP and
-	// do away with metallb deployment here.
-	builder := environment.NewBuilder().WithAddons(kong, metallbaddon.New())
+	builder := environment.NewBuilder().WithAddons(kong)
 
 	t.Log("building the testing environment and Kubernetes cluster")
 	env, err := builder.Build(ctx)
@@ -115,8 +111,8 @@ func testKongAddonWithCustomImage(t *testing.T, tc customImageTest) {
 		require.NoError(t, env.Cleanup(ctx))
 	}()
 
-	t.Log("verifying that addons (kong and metallb) have been loaded into the environment")
-	require.Len(t, env.Cluster().ListAddons(), 2)
+	t.Log("verifying that kong addon have been loaded into the environment")
+	require.Len(t, env.Cluster().ListAddons(), 1)
 
 	t.Log("verifying that the kong deployment is using custom images")
 	deployments := env.Cluster().Client().AppsV1().Deployments(kong.Namespace())


### PR DESCRIPTION
Fix: set `udpProxy.type` to specified proxy service type, because `udpProxy` service is enabled by default and has type `LoadBalancer` by default. By setting this we can set `proxyServiceType` to `ClusterIP` to get rid of dependency on `metallb` in unnecessary test cases. Fixes #540.