### PR TITLE
feat(kong): allow customizing chart version and proxy readiness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.36.0
+
+- Allow customizing Helm chart version and proxy readiness probe used
+  in Kong addon.
+  [#774](https://github.com/Kong/kubernetes-testing-framework/pull/774)
+
 ## v0.35.0
 
 - Support specifying namespace of Kong addon to deploy Kong in certain


### PR DESCRIPTION
Adds `WithHelmChartVersion` and `WithProxyReadinessProbePath` Kong addon builder methods. Modifies the `WithControllerDisabled` method to also alter the `proxyReadinessProbePath` to `/status` so that the installation succeeds if the controller is disabled (otherwise `/status/ready` default would be used which expects Gateway to have a non-empty config loaded/configured).