### PR TITLE
feat: support arbitrary values in helm install

### DIFF
--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -99,6 +99,9 @@ type Addon struct {
 	proxyEnterpriseEnabled            bool
 	proxyEnterpriseSuperAdminPassword string
 	proxyEnterpriseLicenseJSON        string
+	// additionalValues stores values that are set during installing by helm.
+	// for each key-value pair, an argument `--set <key>=<value>` is added.
+	additionalValues map[string]string
 }
 
 type pullSecret struct {
@@ -349,6 +352,10 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 
 	for name, value := range a.proxyEnvVars {
 		a.deployArgs = append(a.deployArgs, "--set", fmt.Sprintf("env.%s=%s", name, value))
+	}
+
+	for name, value := range a.additionalValues {
+		a.deployArgs = append(a.deployArgs, "--set", fmt.Sprintf("%s=%s", name, value))
 	}
 
 	// compile the helm installation values

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -41,16 +41,20 @@ type Builder struct {
 	proxyEnterpriseEnabled            bool
 	proxyEnterpriseSuperAdminPassword string
 	proxyEnterpriseLicenseJSON        string
+	// additionalValues stores values that are set during installing by helm.
+	// for each key-value pair, an argument `--set <key>=<value>` is added.
+	additionalValues map[string]string
 }
 
 // NewBuilder provides a new Builder object for configuring and generating
 // Kong Addon objects which can be deployed to cluster.Clusters
 func NewBuilder() *Builder {
 	builder := &Builder{
-		namespace:    DefaultNamespace,
-		name:         DefaultDeploymentName,
-		deployArgs:   []string{},
-		proxyEnvVars: make(map[string]string),
+		namespace:        DefaultNamespace,
+		name:             DefaultDeploymentName,
+		deployArgs:       []string{},
+		proxyEnvVars:     make(map[string]string),
+		additionalValues: make(map[string]string),
 	}
 	return builder.WithDBLess()
 }
@@ -100,6 +104,8 @@ func (b *Builder) Build() *Addon {
 		proxyEnterpriseEnabled:            b.proxyEnterpriseEnabled,
 		proxyEnterpriseLicenseJSON:        b.proxyEnterpriseLicenseJSON,
 		proxyEnterpriseSuperAdminPassword: b.proxyEnterpriseSuperAdminPassword,
+
+		additionalValues: b.additionalValues,
 	}
 }
 
@@ -225,5 +231,11 @@ func (b *Builder) WithHelmChartVersion(version string) *Builder {
 // WithProxyReadinessProbePath sets the path to use for the proxy readiness probe.
 func (b *Builder) WithProxyReadinessProbePath(path string) *Builder {
 	b.proxyReadinessProbePath = path
+	return b
+}
+
+// WithAdditionalValue sets arbitrary value of installing by helm.
+func (b *Builder) WithAdditonalValue(name, value string) *Builder {
+	b.additionalValues[name] = value
 	return b
 }


### PR DESCRIPTION
support setting arbitrary values in installing kong by helm to support setting `images.effectiveSemver` to fix parsing semver in s integration tests against kong nightly image.
REVIEW: move the setting of other values to `addon.addtionalValues`?