### PR TITLE
fix: correct misspelled function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## v0.38.0
+
+### Breaking changes
+
+- Fix an API name typo. The `WithAdditonalValue` Kong addon builder method is
+  now `WithAdditionalValue`
+
 ## v0.37.0
 
 ### Added
 
-- Allow specifying arbitrary helm values when deploying `Kong` addon.
+- Allow specifying arbitrary helm values when deploying Kong addon.
   [#776](https://github.com/Kong/kubernetes-testing-framework/pull/776)
 
 ## v0.36.0

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -235,7 +235,7 @@ func (b *Builder) WithProxyReadinessProbePath(path string) *Builder {
 }
 
 // WithAdditionalValue sets arbitrary value of installing by helm.
-func (b *Builder) WithAdditonalValue(name, value string) *Builder {
+func (b *Builder) WithAdditionalValue(name, value string) *Builder {
 	b.additionalValues[name] = value
 	return b
 }


### PR DESCRIPTION
Function name had a hard to spot misspelling.

It's a breaking API change, but recent enough that I don't think we should bother deprecating it. AFAIK we only use it in `KIC:test/internal/helpers/ktf.go`.