### PR TITLE
chore(deps): remove exclude github.com/docker/docker v24.0.0+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,6 @@ go 1.21
 
 toolchain go1.21.0
 
-// TODO: remove this when
-// https://github.com/Kong/kubernetes-testing-framework/issues/670
-// is solved.
-exclude github.com/docker/docker v24.0.0+incompatible
-
 require (
 	cloud.google.com/go/container v1.26.0
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Since the version of Docker in GH runners has been updated, the explicit exclusion of 
```
github.com/docker/docker v24.0.0+incompatible
```
is no longer needed. Closes
- #670 