### PR TITLE
chore: release 0.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.39.1
+
+- Removed a module exclude that made `go install` unhappy.
+  [#813](https://github.com/Kong/kubernetes-testing-framework/pull/813)
+
 ## v0.39.0
 
 - Upgrade `metallb` addon to `v0.13.11`


### PR DESCRIPTION
The exclude was quite annoying when I was trying to update, and doubly annoying when I was looking at main and not seeing it. We should release to fix the install docs.