### PR TITLE
feat(kong): allow setting Node ports

### DIFF
--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -95,6 +95,10 @@ type Addon struct {
 	proxyEnvVars                      map[string]string
 	proxyReadinessProbePath           string
 
+	// Node ports
+	httpNodePort  int
+	adminNodePort int
+
 	// proxy server enterprise mode configuration options
 	proxyEnterpriseEnabled            bool
 	proxyEnterpriseSuperAdminPassword string
@@ -372,6 +376,14 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	args = append(args, "--namespace", a.namespace)
 	args = append(args, a.deployArgs...)
 	args = append(args, defaults()...)
+
+	if a.httpNodePort > 0 {
+		args = append(args, "--set", fmt.Sprintf("proxy.http.nodePort=%d", a.httpNodePort))
+	}
+	if a.adminNodePort > 0 {
+		args = append(args, "--set", fmt.Sprintf("admin.http.nodePort=%d", a.adminNodePort))
+	}
+
 	args = append(args, exposePortsDefault()...)
 	a.logger.Debugf("helm install arguments: %+v", args)
 
@@ -573,10 +585,8 @@ func defaults() []string {
 	return []string{
 		// we configure a cluster network exposed admin API over HTTP with no auth for testing convenience,
 		// but again keep in mind this is meant ONLY for transient testing scenarios and isn't secure.
-		"--set", "proxy.http.nodePort=30080",
 		"--set", "admin.enabled=true",
 		"--set", "admin.http.enabled=true",
-		"--set", "admin.http.nodePort=32080",
 		"--set", "admin.tls.enabled=false",
 		"--set", "tls.enabled=false",
 		"--set", "udpProxy.enabled=true",

--- a/pkg/clusters/addons/kong/vars.go
+++ b/pkg/clusters/addons/kong/vars.go
@@ -53,4 +53,8 @@ const (
 	// DefaultProxyNodePort indicates the default NodePort that will be used for
 	// the proxy when applicable.
 	DefaultProxyNodePort = 30080
+
+	// DefaultAdminNodePort indicates the default NodePort that will be used for
+	// the admin API when applicable.
+	DefaultAdminNodePort = 32080
 )

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -13,7 +13,7 @@ import (
 
 	"go4.org/netipx"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -121,7 +121,7 @@ func (a *Addon) Ready(ctx context.Context, cluster clusters.Cluster) ([]runtime.
 	deployment, err := cluster.Client().AppsV1().Deployments(DefaultNamespace).
 		Get(ctx, "controller", metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, false, nil
 		}
 		return nil, false, err
@@ -157,7 +157,7 @@ func (a *Addon) deployMetallbForKindCluster(ctx context.Context, cluster cluster
 	// ensure the namespace for metallb is created
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: DefaultNamespace}}
 	if _, err := cluster.Client().CoreV1().Namespaces().Create(ctx, &ns, metav1.CreateOptions{}); err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 	}
@@ -194,7 +194,7 @@ func (a *Addon) deployMetallbForKindCluster(ctx context.Context, cluster cluster
 		},
 	}
 	if _, err := cluster.Client().CoreV1().Secrets(ns.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 	}
@@ -243,7 +243,7 @@ func createIPAddressPool(ctx context.Context, cluster clusters.Cluster, dockerNe
 		}, metav1.CreateOptions{})
 
 		if err != nil {
-			if errors.IsAlreadyExists(err) {
+			if apierrors.IsAlreadyExists(err) {
 				// delete the existing resource and recreate it in another round of loop.
 				err = res.Delete(ctx, addressPoolName, metav1.DeleteOptions{})
 			}
@@ -286,7 +286,7 @@ func createL2Advertisement(ctx context.Context, cluster clusters.Cluster) error 
 		}, metav1.CreateOptions{})
 
 		if err != nil {
-			if errors.IsAlreadyExists(err) {
+			if apierrors.IsAlreadyExists(err) {
 				// delete the existing resource and recreate it in another round of loop.
 				err = res.Delete(ctx, l2AdvertisementName, metav1.DeleteOptions{})
 			}


### PR DESCRIPTION
Add possibility to specify NodePorts for kong's admin API and HTTP port.

This is required for https://github.com/Kong/kubernetes-ingress-controller/pull/4823 to prevent tests colliding when deploying multiple kong addons to the same cluster.