### PR TITLE
chore(linter): in switch case default signifies exhaustive match and fix forbidigo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,6 +35,8 @@ linters:
   - wastedassign
 
 linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
   gci:
     sections:
     - standard
@@ -82,7 +84,7 @@ linters-settings:
       - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
         alias: gateway${1}
   forbidigo:
-    exclude_godoc_examples: false
+    exclude-godoc-examples: false
     forbid:
       - 'CoreV1\(\)\.Endpoints(# use DiscoveryV1 EndpointSlices API instead)?'
       - 'corev1\.Endpoint(# use DiscoveryV1 EndpointSlices API instead)?'

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -628,7 +628,7 @@ func urlForService(ctx context.Context, cluster clusters.Cluster, nsn types.Name
 		return nil, err
 	}
 
-	switch service.Spec.Type { //nolint:exhaustive
+	switch service.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
 		if len(service.Status.LoadBalancer.Ingress) == 1 {
 			return url.Parse(fmt.Sprintf("http://%s:%d", service.Status.LoadBalancer.Ingress[0].IP, port))

--- a/pkg/clusters/addons/kong/builder.go
+++ b/pkg/clusters/addons/kong/builder.go
@@ -86,7 +86,7 @@ func (b *Builder) Build() *Addon {
 	}
 
 	// LoadBalancer is used by default for historical and convenience reasons.
-	switch b.proxyServiceType { //nolint:exhaustive
+	switch b.proxyServiceType {
 	case "":
 		b.proxyServiceType = corev1.ServiceTypeLoadBalancer
 	case corev1.ServiceTypeNodePort:
@@ -94,6 +94,7 @@ func (b *Builder) Build() *Addon {
 		if b.httpNodePort == 0 {
 			b.httpNodePort = DefaultProxyNodePort
 		}
+	default:
 	}
 
 	return &Addon{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR adjusts the configuration of golangci-lint, to get rid of `//nolint:exhaustive`. It is sensible always to treat `switch` statements that include case `default` as exhaustive.

Also, it fixes a typo in forbidigo configuration.
