### PR TITLE
chore: update metallb to 0.13.12 and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.41.1
+
+- Updated metallb to v0.13.12.
+
 ## v0.41.0
 
 - Allow deploying multiple kong addons to the cluster and identifying them by

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -144,7 +144,7 @@ func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][
 // -----------------------------------------------------------------------------
 
 var (
-	metalManifest = "https://github.com/metallb/metallb/config/native?ref=v0.13.11&timeout=2m"
+	metalManifest = "https://github.com/metallb/metallb/config/native?ref=v0.13.12&timeout=2m"
 	secretKeyLen  = 128
 )
 


### PR DESCRIPTION
Update metallb. This is mostly to pull in https://github.com/metallb/metallb/pull/2097

We previously set the addon to delete any existing pool if one with the desired name already exists in https://github.com/Kong/kubernetes-testing-framework/issues/381

Earlier metallb versions handled pool changes by keeping Service IPs assigned by the previous pool. These IPs would become unrouteable and rather useless. We could probably adjust the reuse conflict by just letting the old pool remain instead of deleting it and creating a new one instead, but I'm opting to leave this behavior as-is since the latest metallb does handle it.

~Draft to see if I can't actually do this because our test suites aren't smart enough to update their IPs.~ From some basic testing with the KIC integration tests, it does correctly learn the new IP.