### PR TITLE
fix: change Kong Gateway Enterprise default image to Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump Kong Gateway Enterprise default image to 3.4
   [#867](https://github.com/Kong/kubernetes-testing-framework/pull/867)
+  [#868](https://github.com/Kong/kubernetes-testing-framework/pull/868)
 
 ## v0.41.1
 

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -48,7 +48,7 @@ const (
 	DefaultEnterpriseImageRepo = "kong/kong-gateway"
 
 	// DefaultEnterpriseImageTag latest kong enterprise image tag
-	DefaultEnterpriseImageTag = "3.4-alpine"
+	DefaultEnterpriseImageTag = "3.4-ubuntu"
 
 	// DefaultEnterpriseLicenseSecretName is the name that will be used by default for the
 	// Kubernetes secret containing the Kong enterprise license that will be


### PR DESCRIPTION
PR https://github.com/Kong/kubernetes-testing-framework/pull/867 bumped image from `3.3.-alpine` to `3.4-alpine` despite failures in tests ([this](https://github.com/Kong/kubernetes-testing-framework/actions/runs/6773122543/job/18407259479) and [that](https://github.com/Kong/kubernetes-testing-framework/actions/runs/6773122543/job/18407259793)) it was successfully merged. A fix for this to not allow merging is presented in 
- https://github.com/Kong/kubernetes-testing-framework/pull/869

Since `3.4` the Alpine image is no longer built, the recommended one is Ubuntu so this PR is setting it.