### PR TITLE
fix(ci): fail integration-tests-passed when tests don't pass

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -150,11 +150,13 @@ jobs:
 
   integration-tests-passed:
     needs: integration-tests
-    if: always() && !contains(needs.*.result, 'failure')
+    if: always()
     runs-on: ubuntu-latest
     steps:
-    - name: integrations tests pased
-      run: echo all integrations tests passed
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Some jobs failed or were cancelled."
+          exit 1
 
   setup-e2e-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR https://github.com/Kong/kubernetes-testing-framework/pull/867 bumped image from `3.3.-alpine` to `3.4-alpine` despite failures in tests ([this](https://github.com/Kong/kubernetes-testing-framework/actions/runs/6773122543/job/18407259479) and [that](https://github.com/Kong/kubernetes-testing-framework/actions/runs/6773122543/job/18407259793)) it was successfully merged. 

This PR fixes it, it should not allow merge when any test fails, a fix for a bump of the image is in 
- https://github.com/Kong/kubernetes-testing-framework/pull/868