### PR TITLE
chore(ci): remove pulp password usage

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -62,7 +62,6 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        password: ${{ secrets.PULP_PASSWORD }}
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: checkout repository
@@ -92,7 +91,6 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        password: ${{ secrets.PULP_PASSWORD }}
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     # --------------------------------------------------------------------------

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,7 +114,6 @@ jobs:
       if: steps.detect_if_should_run_enterprise.outputs.result == 'true'
       id: license
       with:
-        password: ${{ secrets.PULP_PASSWORD }}
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: setup golang
@@ -199,7 +198,6 @@ jobs:
         if: steps.detect_if_should_run.outputs.result == 'true'
         id: license
         with:
-          password: ${{ secrets.PULP_PASSWORD }}
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: checkout repository


### PR DESCRIPTION
After https://github.com/Kong/kong-license/pull/25 has been merged, we only care about 1Password token so remove the reference to Pulp password.