### PR TITLE
feat: add WithReleaseChannel to GKE cluster builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.43.0
 
-Nothing
+- Added `WithReleaseChannel` to the GKE cluster builder to allow specifying
+  a release channel for the cluster.
+  [#911](https://github.com/Kong/kubernetes-testing-framework/pull/911)
 
 ## v0.42.0
 

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -64,6 +64,7 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 	builder.WithWaitForTeardown(false)
 	builder.WithCreateSubnet(createSubnet)
 	builder.WithLabels(map[string]string{"test-cluster": "true"})
+	builder.WithReleaseChannel(gke.ReleaseChannelRapid)
 
 	t.Logf("building cluster %s (this can take some time)", builder.Name)
 	cluster, err := builder.Build(ctx)
@@ -102,6 +103,10 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 	if createSubnet {
 		require.NotEqual(t, "default", gkeCluster.Subnetwork)
 	}
+
+	t.Log("verify rapid release channel used")
+	require.NotNil(t, gkeCluster.ReleaseChannel)
+	require.Equal(t, containerpb.ReleaseChannel_RAPID, gkeCluster.ReleaseChannel.Channel)
 
 	t.Log("loading the gke cluster into a testing environment and deploying kong addon")
 	env, err := environments.NewBuilder().WithAddons(kong.New()).WithExistingCluster(cluster).Build(ctx)


### PR DESCRIPTION
Allow specifying a release channel to use images from when creating a GKE cluster. It allows setting all of the existing release channels Google maintains ([release notes](https://cloud.google.com/kubernetes-engine/docs/release-notes)).