### PR TITLE
Revert actions/upload-artifact and actions/download-artifact bumps to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
     # --------------------------------------------------------------------------
 
     - name: download checksums artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: CHECKSUMS
 
@@ -88,7 +88,7 @@ jobs:
       run: cat CHECKSUMS.* > CHECKSUMS
 
     - name: download binary artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: bin
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: build for ${{ matrix.os }} ${{ matrix.arch }}
       run: make build GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }}
     - name: upload ${{ matrix.os }} ${{ matrix.arch }} artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: bin
         path: build/ktf.${{ matrix.os }}.${{ matrix.arch }}
@@ -59,7 +59,7 @@ jobs:
       run: sha256sum ktf.${{ matrix.os }}.${{ matrix.arch }} >> CHECKSUMS.${{ matrix.os }}.${{ matrix.arch }}
       working-directory: ./build/
     - name: upload checksum for ${{ matrix.os }} ${{ matrix.arch }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: CHECKSUMS
         path: build/CHECKSUMS.${{ matrix.os }}.${{ matrix.arch }}


### PR DESCRIPTION
Reverts major version bumps of actions/upload-artifact and actions/download-artifact to v4 that introduced breaking changes that we do not have yet direct remedy for. Created an issue to track this: https://github.com/Kong/kubernetes-testing-framework/issues/912