### PR TITLE
fix: negotiate Docker API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.44.0
+
+- Added a call to `NegotiateAPIVersion` when creating a Docker client to
+  ensure that the client is able to communicate with the Docker daemon.
+  [#932](https://github.com/Kong/kubernetes-testing-framework/pull/932)
+
 ## v0.43.0
 
 - Added `WithReleaseChannel` to the GKE cluster builder to allow specifying

--- a/pkg/utils/docker/client.go
+++ b/pkg/utils/docker/client.go
@@ -1,0 +1,19 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/docker/docker/client"
+)
+
+// NewNegotiatedClientWithOpts is a wrapper around docker.NewClientWithOpts that negotiates the API version
+// with the server.
+func NewNegotiatedClientWithOpts(ctx context.Context, opts ...client.Opt) (*client.Client, error) {
+	c, err := client.NewClientWithOpts(opts...)
+	if err != nil {
+		return nil, err
+	}
+	// Make sure the client API version matches server's API version to avoid discrepancy issues.
+	c.NegotiateAPIVersion(ctx)
+	return c, nil
+}

--- a/pkg/utils/docker/command.go
+++ b/pkg/utils/docker/command.go
@@ -11,7 +11,7 @@ import (
 // given command and arguments on the given container (by ID) privileged.
 func RunPrivilegedCommand(ctx context.Context, containerID, command string, args ...string) error {
 	// connect to the local docker env
-	dockerc, err := client.NewClientWithOpts(client.FromEnv)
+	dockerc, err := NewNegotiatedClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/docker/copy.go
+++ b/pkg/utils/docker/copy.go
@@ -16,7 +16,7 @@ import (
 // ReadFileFromContainer reads a specific file from a given container by ID.
 func ReadFileFromContainer(ctx context.Context, containerID string, path string) (*bytes.Buffer, error) {
 	// connect to the local docker environment
-	dockerc, err := client.NewClientWithOpts(client.FromEnv)
+	dockerc, err := NewNegotiatedClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func WriteFileToContainer(ctx context.Context, containerID string, path string, 
 	}
 
 	// connect to the local docker environment
-	dockerc, err := client.NewClientWithOpts(client.FromEnv)
+	dockerc, err := NewNegotiatedClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		return fmt.Errorf("could not create a client with the local docker system: %w", err)
 	}

--- a/pkg/utils/docker/docker.go
+++ b/pkg/utils/docker/docker.go
@@ -16,11 +16,12 @@ import (
 // InspectDockerContainer is a helper function that uses the local docker environment
 // provides the full container spec for a container present in that environment by name.
 func InspectDockerContainer(containerID string) (*types.ContainerJSON, error) {
-	dockerc, err := client.NewClientWithOpts(client.FromEnv)
+	ctx := context.Background()
+	dockerc, err := NewNegotiatedClientWithOpts(ctx, client.FromEnv)
 	if err != nil {
 		return nil, err
 	}
-	containerJSON, err := dockerc.ContainerInspect(context.Background(), containerID)
+	containerJSON, err := dockerc.ContainerInspect(ctx, containerID)
 	return &containerJSON, err
 }
 


### PR DESCRIPTION
When a Docker daemon doesn't support an API version that's used by the Go client, it will reject communication as in the [issue we've faced in KIC](https://github.com/Kong/kubernetes-ingress-controller/pull/5464#issuecomment-1902932869). This change is to avoid such errors by making sure that the client downgrades the API automatically in case the daemon doesn't support the newest one.

Should unblock https://github.com/Kong/kubernetes-testing-framework/pull/931.