### PR TITLE
feat: use kuma version when installing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- `Kuma` addon now properly uses the Helm chart version passed in its builder's
+  `WithVersion` method.
+  [#949](https://github.com/Kong/kubernetes-testing-framework/pull/949)
+
 ## v0.44.0
 
 - Added a call to `NegotiateAPIVersion` when creating a Docker client to

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -61,7 +61,7 @@ func (a *Addon) Namespace() string {
 	return Namespace
 }
 
-// Version returns the version of the Kuma Helm chart that will be deployed by the addon.
+// Version returns the version of the Kuma Helm chart deployed by the addon.
 // If the version is not set, the second return value will be false and the latest local
 // chart version will be used.
 func (a *Addon) Version() (v semver.Version, ok bool) {

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -45,7 +45,7 @@ type Addon struct {
 	name   string
 	logger *logrus.Logger
 
-	version semver.Version
+	version *semver.Version
 
 	mtlsEnabled bool
 }
@@ -63,7 +63,10 @@ func (a *Addon) Namespace() string {
 
 // Version indicates the Kuma version for this addon.
 func (a *Addon) Version() semver.Version {
-	return a.version
+	if a.version == nil {
+		return semver.Version{}
+	}
+	return *a.version
 }
 
 // -----------------------------------------------------------------------------
@@ -143,6 +146,10 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 
 	// if the dbmode is postgres, set several related values
 	args := []string{"--kubeconfig", kubeconfig.Name(), "install", DefaultReleaseName, "kuma/kuma"}
+
+	if a.version != nil {
+		args = append(args, "--version", a.version.String())
+	}
 
 	// compile the helm installation values
 	args = append(args, "--create-namespace", "--namespace", Namespace)

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -61,12 +61,14 @@ func (a *Addon) Namespace() string {
 	return Namespace
 }
 
-// Version indicates the Kuma version for this addon.
-func (a *Addon) Version() semver.Version {
+// Version returns the version of the Kuma Helm chart that will be deployed by the addon.
+// If the version is not set, the second return value will be false and the latest local
+// chart version will be used.
+func (a *Addon) Version() (v semver.Version, ok bool) {
 	if a.version == nil {
-		return semver.Version{}
+		return semver.Version{}, false
 	}
-	return *a.version
+	return *a.version, true
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/clusters/addons/kuma/builder.go
+++ b/pkg/clusters/addons/kuma/builder.go
@@ -14,7 +14,7 @@ import (
 // Builder is a configuration tool to generate Kuma cluster addons.
 type Builder struct {
 	name    string
-	version semver.Version
+	version *semver.Version
 	logger  *logrus.Logger
 
 	mtlsEnabled bool
@@ -29,7 +29,7 @@ func NewBuilder() *Builder {
 
 // WithVersion configures the specific version of Kuma which should be deployed.
 func (b *Builder) WithVersion(version semver.Version) *Builder {
-	b.version = version
+	b.version = &version
 	return b
 }
 

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -28,6 +28,11 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
+const (
+	gkeVersionMajor = 1
+	gkeVersionMinor = 29
+)
+
 var (
 	gkeCreds    = os.Getenv(gke.GKECredsVar)
 	gkeProject  = os.Getenv(gke.GKEProjectVar)
@@ -60,7 +65,7 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 
 	t.Logf("configuring the GKE cluster PROJECT=(%s) LOCATION=(%s)", gkeProject, gkeLocation)
 	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation)
-	builder.WithClusterMinorVersion(1, 29)
+	builder.WithClusterMinorVersion(gkeVersionMajor, gkeVersionMinor)
 	builder.WithWaitForTeardown(false)
 	builder.WithCreateSubnet(createSubnet)
 	builder.WithLabels(map[string]string{"test-cluster": "true"})
@@ -118,8 +123,8 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 	t.Log("validating kubernetes cluster version")
 	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), kubernetesVersion.Major)
-	require.Equal(t, uint64(24), kubernetesVersion.Minor)
+	require.Equal(t, gkeVersionMajor, kubernetesVersion.Major)
+	require.Equal(t, gkeVersionMinor, kubernetesVersion.Minor)
 
 	t.Log("verifying that the kong addon deployed both proxy and controller")
 	kongAddon, err := env.Cluster().GetAddon("kong")

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -60,7 +60,7 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 
 	t.Logf("configuring the GKE cluster PROJECT=(%s) LOCATION=(%s)", gkeProject, gkeLocation)
 	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation)
-	builder.WithClusterMinorVersion(1, 24)
+	builder.WithClusterMinorVersion(1, 29)
 	builder.WithWaitForTeardown(false)
 	builder.WithCreateSubnet(createSubnet)
 	builder.WithLabels(map[string]string{"test-cluster": "true"})

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -123,8 +123,8 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 	t.Log("validating kubernetes cluster version")
 	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	require.Equal(t, gkeVersionMajor, kubernetesVersion.Major)
-	require.Equal(t, gkeVersionMinor, kubernetesVersion.Minor)
+	require.Equal(t, uint64(gkeVersionMajor), kubernetesVersion.Major)
+	require.Equal(t, uint64(gkeVersionMinor), kubernetesVersion.Minor)
 
 	t.Log("verifying that the kong addon deployed both proxy and controller")
 	kongAddon, err := env.Cluster().GetAddon("kong")


### PR DESCRIPTION
In Kuma addon builder we allow setting a version, but we don't use it when calling `helm install`.