### PR TITLE
feat: support arbitrary Kuma Helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added support for arbitrary Helm chart values to the Kuma plugin.
+  [#958](https://github.com/Kong/kubernetes-testing-framework/pull/958)
+
 ## v0.45.0
 
 - `Kuma` addon now properly uses the Helm chart version passed in its builder's

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -47,7 +47,8 @@ type Addon struct {
 
 	version *semver.Version
 
-	mtlsEnabled bool
+	mtlsEnabled      bool
+	additionalValues map[string]string
 }
 
 // New produces a new clusters.Addon for Kuma with MTLS enabled
@@ -155,6 +156,11 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 
 	// compile the helm installation values
 	args = append(args, "--create-namespace", "--namespace", Namespace)
+
+	for name, value := range a.additionalValues {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", name, value))
+	}
+
 	a.logger.Debugf("helm install arguments: %+v", args)
 
 	// Sometimes running helm install fails. Just in case this happens, retry.

--- a/pkg/clusters/addons/kuma/builder.go
+++ b/pkg/clusters/addons/kuma/builder.go
@@ -17,13 +17,15 @@ type Builder struct {
 	version *semver.Version
 	logger  *logrus.Logger
 
-	mtlsEnabled bool
+	mtlsEnabled      bool
+	additionalValues map[string]string
 }
 
 // NewBuilder provides a new Builder object for configuring Kuma cluster addons.
 func NewBuilder() *Builder {
 	return &Builder{
-		name: string(AddonName),
+		name:             string(AddonName),
+		additionalValues: make(map[string]string),
 	}
 }
 
@@ -48,6 +50,12 @@ func (b *Builder) WithMTLS() *Builder {
 	return b
 }
 
+// WithAdditionalValue sets a key and value to pass to Helm using --set.
+func (b *Builder) WithAdditionalValue(name, value string) *Builder {
+	b.additionalValues[name] = value
+	return b
+}
+
 // Build generates a new kong cluster.Addon which can be loaded and deployed
 // into a test Environment's cluster.Cluster.
 func (b *Builder) Build() *Addon {
@@ -59,6 +67,7 @@ func (b *Builder) Build() *Addon {
 		version: b.version,
 		logger:  b.logger,
 
-		mtlsEnabled: b.mtlsEnabled,
+		mtlsEnabled:      b.mtlsEnabled,
+		additionalValues: b.additionalValues,
 	}
 }


### PR DESCRIPTION
Add support for arbitrary chart settings to the Kuma plugin, inspired by the existing Kong plugin functionality.

I added this to test some additional Kuma settings in CI to try and find some fix for the KIC session stickiness issues we've seen with Kong 3.6. Didn't find any fix, but this is generic enough that we may as well add it anyway.