### PR TITLE
core(lint): fix reported issues after golangci-lint update

### DIFF
--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -63,7 +63,7 @@ func init() { //nolint:gochecknoinits
 var environmentsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create a new testing environment",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := context.WithTimeout(context.Background(), EnvironmentCreateTimeout)
 		defer cancel()
 
@@ -294,7 +294,7 @@ func init() { //nolint:gochecknoinits
 var environmentsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "delete a testing environment",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := context.WithTimeout(context.Background(), EnvironmentCreateTimeout)
 		defer cancel()
 

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -246,7 +246,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 		if opts.Server == "" {
 			opts.Server = "https://index.docker.io/v1/"
 		}
-		opts.PrintObj = func(obj runtime.Object) error {
+		opts.PrintObj = func(_ runtime.Object) error {
 			return nil
 		}
 

--- a/pkg/utils/kong/fake_admin_api.go
+++ b/pkg/utils/kong/fake_admin_api.go
@@ -41,7 +41,7 @@ type FakeAdminAPIServer struct {
 func NewFakeAdminAPIServer() (*FakeAdminAPIServer, error) {
 	// start up the fake admin api server
 	mocks := make(chan AdminAPIResponse, maxMocks)
-	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		select {
 		case override := <-mocks:
 			// run any callbacks that were configured in the mock (these are optional)


### PR DESCRIPTION
Fixes issues reported e.g. [here](https://github.com/Kong/kubernetes-testing-framework/actions/runs/7843703310/job/21404600590) after update of golagci-lint 
<img width="987" alt="image" src="https://github.com/Kong/kubernetes-testing-framework/assets/9593424/4d03892d-445c-447a-a171-0bd763f2f857">
