### PR TITLE
Backport Kuma updates to 0.39

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,12 +3,12 @@ name: lint
 on:
   pull_request:
     branches:
-    - '*'
+    - '**'
   push:
     branches:
     - 'main'
     tags:
-    - '*'
+    - '**'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
     - 'main'
+    - 'release/[0-9]+.[0-9]+.x'
   push:
     branches:
     - 'main'
@@ -114,7 +115,7 @@ jobs:
       if: steps.detect_if_should_run_enterprise.outputs.result == 'true'
       id: license
       with:
-        password: ${{ secrets.PULP_PASSWORD }}
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: setup golang
       uses: actions/setup-go@v4
@@ -196,7 +197,7 @@ jobs:
         if: steps.detect_if_should_run.outputs.result == 'true'
         id: license
         with:
-          password: ${{ secrets.PULP_PASSWORD }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: checkout repository
         if: steps.detect_if_should_run.outputs.result == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.39.2
+
+- Backport Kuma changes to honor version and handle Kuma 2.6.0 traffic
+  permissions properly.
+  [#1017](https://github.com/Kong/kubernetes-testing-framework/pull/1017)
+
 ## v0.39.1
 
 - Removed a module exclude that made `go install` unhappy.

--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -62,7 +62,7 @@ func init() { //nolint:gochecknoinits
 var environmentsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create a new testing environment",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := context.WithTimeout(context.Background(), EnvironmentCreateTimeout)
 		defer cancel()
 
@@ -286,7 +286,7 @@ func init() { //nolint:gochecknoinits
 var environmentsDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "delete a testing environment",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := context.WithTimeout(context.Background(), EnvironmentCreateTimeout)
 		defer cancel()
 

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -240,7 +240,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 		if opts.Server == "" {
 			opts.Server = "https://index.docker.io/v1/"
 		}
-		opts.PrintObj = func(obj runtime.Object) error {
+		opts.PrintObj = func(_ runtime.Object) error {
 			return nil
 		}
 
@@ -606,7 +606,8 @@ func urlForService(ctx context.Context, cluster clusters.Cluster, nsn types.Name
 		return nil, err
 	}
 
-	switch service.Spec.Type { //nolint:exhaustive
+	//nolint:exhaustive
+	switch service.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
 		if len(service.Status.LoadBalancer.Ingress) == 1 {
 			return url.Parse(fmt.Sprintf("http://%s:%d", service.Status.LoadBalancer.Ingress[0].IP, port))

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -225,12 +225,36 @@ spec:
       name: ca-1
       type: builtin
     enabledBackend: ca-1`
+
+	allowAllTrafficPermission = `apiVersion: kuma.io/v1alpha1
+kind: MeshTrafficPermission
+metadata:
+  name: allow-all
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  from:
+  - targetRef:
+      kind: Mesh
+    default:
+      action: Allow`
+)
+
+var (
+	// From Kuma 2.6.0, the default mesh traffic permission is no longer created by default
+	// and must be created manually if mTLS is enabled.
+	// https://github.com/kumahq/kuma/blob/2.6.0/UPGRADE.md#default-trafficroute-and-trafficpermission-resources-are-not-created-when-creating-a-new-mesh
+	installDefaultMeshTrafficPermissionCutoffVersion = semver.MustParse("2.6.0")
 )
 
 // enableMTLS attempts to apply a Mesh resource with a basic retry mechanism to deal with delays in the Kuma webhook
 // startup
 func (a *Addon) enableMTLS(ctx context.Context, cluster clusters.Cluster) (err error) {
 	ticker := time.NewTicker(5 * time.Second) //nolint:gomnd
+	defer ticker.Stop()
 	timeoutTimer := time.NewTimer(time.Minute)
 
 	for {
@@ -238,7 +262,12 @@ func (a *Addon) enableMTLS(ctx context.Context, cluster clusters.Cluster) (err e
 		case <-ctx.Done():
 			return fmt.Errorf("context completed while retrying to apply Mesh")
 		case <-ticker.C:
-			err = clusters.ApplyManifestByYAML(ctx, cluster, mtlsEnabledDefaultMesh)
+			yamlToApply := mtlsEnabledDefaultMesh
+			if v, ok := a.Version(); ok && v.GTE(installDefaultMeshTrafficPermissionCutoffVersion) {
+				a.logger.Infof("Kuma version is %s or later, creating default mesh traffic permission", installDefaultMeshTrafficPermissionCutoffVersion)
+				yamlToApply = strings.Join([]string{mtlsEnabledDefaultMesh, allowAllTrafficPermission}, "\n---\n")
+			}
+			err = clusters.ApplyManifestByYAML(ctx, cluster, yamlToApply)
 			if err == nil {
 				return nil
 			}

--- a/pkg/clusters/addons/kuma/builder.go
+++ b/pkg/clusters/addons/kuma/builder.go
@@ -14,7 +14,7 @@ import (
 // Builder is a configuration tool to generate Kuma cluster addons.
 type Builder struct {
 	name    string
-	version semver.Version
+	version *semver.Version
 	logger  *logrus.Logger
 
 	mtlsEnabled bool
@@ -29,7 +29,7 @@ func NewBuilder() *Builder {
 
 // WithVersion configures the specific version of Kuma which should be deployed.
 func (b *Builder) WithVersion(version semver.Version) *Builder {
-	b.version = version
+	b.version = &version
 	return b
 }
 

--- a/pkg/environments/builder.go
+++ b/pkg/environments/builder.go
@@ -185,7 +185,7 @@ func (b *Builder) Build(ctx context.Context) (env Environment, err error) {
 			cluster: cluster,
 		}, nil
 	case 1:
-		return nil, addonDeploymentErrors[0] //nolint:gosec
+		return nil, addonDeploymentErrors[0]
 	default:
 		errMsgs := make([]string, 0, totalFailures)
 		for _, err := range addonDeploymentErrors {

--- a/pkg/utils/kong/fake_admin_api.go
+++ b/pkg/utils/kong/fake_admin_api.go
@@ -41,7 +41,7 @@ type FakeAdminAPIServer struct {
 func NewFakeAdminAPIServer() (*FakeAdminAPIServer, error) {
 	// start up the fake admin api server
 	mocks := make(chan AdminAPIResponse, maxMocks)
-	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		select {
 		case override := <-mocks:
 			// run any callbacks that were configured in the mock (these are optional)

--- a/test/e2e/gke_cluster_test.go
+++ b/test/e2e/gke_cluster_test.go
@@ -28,6 +28,11 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/utils/kubernetes/generators"
 )
 
+const (
+	gkeVersionMajor = 1
+	gkeVersionMinor = 29
+)
+
 var (
 	gkeCreds    = os.Getenv(gke.GKECredsVar)
 	gkeProject  = os.Getenv(gke.GKEProjectVar)
@@ -60,7 +65,7 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 
 	t.Logf("configuring the GKE cluster PROJECT=(%s) LOCATION=(%s)", gkeProject, gkeLocation)
 	builder := gke.NewBuilder([]byte(gkeCreds), gkeProject, gkeLocation)
-	builder.WithClusterMinorVersion(1, 24)
+	builder.WithClusterMinorVersion(gkeVersionMajor, gkeVersionMinor)
 	builder.WithWaitForTeardown(false)
 	builder.WithCreateSubnet(createSubnet)
 	builder.WithLabels(map[string]string{"test-cluster": "true"})
@@ -113,8 +118,8 @@ func testGKECluster(t *testing.T, createSubnet bool) {
 	t.Log("validating kubernetes cluster version")
 	kubernetesVersion, err := env.Cluster().Version()
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), kubernetesVersion.Major)
-	require.Equal(t, uint64(24), kubernetesVersion.Minor)
+	require.Equal(t, uint64(gkeVersionMajor), kubernetesVersion.Major)
+	require.Equal(t, uint64(gkeVersionMinor), kubernetesVersion.Minor)
 
 	t.Log("verifying that the kong addon deployed both proxy and controller")
 	kongAddon, err := env.Cluster().GetAddon("kong")


### PR DESCRIPTION
Backport https://github.com/Kong/kubernetes-testing-framework/commit/fe761fa03cc425dbc3c76bcd35246b5fc41b9ca7 and https://github.com/Kong/kubernetes-testing-framework/commit/78164723d50b1012015d938c9cf4dc7720219c3e to 0.39 and release 0.39.2.

Update CI to test on PRs to release branches. Update license handling for this release branch.

---

KIC 2.12 is able to pass E2E with this in place: https://github.com/Kong/kubernetes-ingress-controller/pull/5760#issuecomment-2026047921

---

This technically breaks semver, but we don't really have anywhere else to stuff it. Maybe you can call the addon not supporting version args and not supporting 2.6 "bugs" for the sake of discussion :shrug: 

Updating KIC 2.x to use the latest KTF causes [all sorts of conflicts](https://github.com/Kong/kubernetes-ingress-controller/pull/5759) due to dependency hell with packages that both KTF and KIC import. We don't have a compelling need to actually update those in 2.x, so trying to make a backported KTF version that can run Kuma tests without pulling updates is much simpler.

@randmonkey can you confirm the exact nature of the Kuma failures? Was it just that it was trying to use latest without the 2.6 fix? IDK if we'd also need to pin the Kuma version in the 2.x KIC tests after this.