### PR TITLE
chore(ci): fix release workflow's license step

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -62,7 +62,7 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        password: ${{ secrets.PULP_PASSWORD }}
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     - name: checkout repository
       uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
     - uses: Kong/kong-license@master
       id: license
       with:
-        password: ${{ secrets.PULP_PASSWORD }}
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     # --------------------------------------------------------------------------
     # Repository Checkout


### PR DESCRIPTION
Fix for https://github.com/Kong/kubernetes-testing-framework/actions/runs/8479160134/job/23232712143. 