### PR TITLE
feat: publish kubectl.RunKustomize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## v0.47.0
+
+### Added
+
+- The former `kubectl.runKustomize` helper is now the public
+  `kubectl.RunKustomize`. This function allows building an existing
+  kustomization directory.
+
 ## v0.46.0
 
 ### Breaking changes

--- a/pkg/utils/kubernetes/kubectl/kustomize.go
+++ b/pkg/utils/kubernetes/kubectl/kustomize.go
@@ -40,15 +40,15 @@ func GetKustomizedManifest(kustomization types.Kustomization, manifests ...io.Re
 	if err != nil {
 		return nil, err
 	}
-	kustomized, err := runKustomize(workDir)
+	kustomized, err := RunKustomize(workDir)
 	if err != nil {
 		return nil, err
 	}
 	return bytes.NewReader(kustomized), nil
 }
 
-// runKustomize runs kustomize on a path and returns the YAML output.
-func runKustomize(path string) ([]byte, error) {
+// RunKustomize runs kustomize on a path and returns the YAML output.
+func RunKustomize(path string) ([]byte, error) {
 	k := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
 	m, err := k.Run(filesys.MakeFsOnDisk(), path)
 	if err != nil {


### PR DESCRIPTION
Publish a previously private helper. If you have an existing complete kustomization dir whose result isn't already built, this function lets you build it and get the result, as `[]byte`.

Release 0.47