### PR TITLE
chore(lint): enable gocritic and fix reported issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,9 +11,9 @@ linters:
   - exportloopref
   - forbidigo
   - gochecknoinits
+  - gocritic
   - gofmt
   - goimports
-  - gomnd
   - gomodguard
   - gosec
   - gci
@@ -21,8 +21,8 @@ linters:
   - govet
   - importas
   - ineffassign
-  - megacheck
   - misspell
+  - mnd
   - nilerr
   - nolintlint
   - predeclared
@@ -88,5 +88,4 @@ linters-settings:
     forbid:
       - 'CoreV1\(\)\.Endpoints(# use DiscoveryV1 EndpointSlices API instead)?'
       - 'corev1\.Endpoint(# use DiscoveryV1 EndpointSlices API instead)?'
-issues:
-  fix: true
+

--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -25,7 +25,7 @@ import (
 // Environments - Base Command
 // -----------------------------------------------------------------------------
 
-func init() { //nolint:gochecknoinits
+func init() { //nolint:init
 	rootCmd.AddCommand(environmentsCmd)
 }
 
@@ -39,7 +39,7 @@ var environmentsCmd = &cobra.Command{
 // Environments - Create Subcommand
 // -----------------------------------------------------------------------------
 
-func init() { //nolint:gochecknoinits
+func init() { //nolint:init
 	environmentsCmd.AddCommand(environmentsCreateCmd)
 
 	// environment naming
@@ -240,7 +240,7 @@ func configureKongAddon(cmd *cobra.Command, envBuilder *environments.Builder) *e
 		if len(imageParts) == 1 {
 			imageParts = append(imageParts, "latest")
 		}
-		if len(imageParts) != 2 { //nolint:gomnd
+		if len(imageParts) != 2 { //nolint:mnd
 			cobra.CheckErr(fmt.Errorf("malformed --kong-gateway-image: %s", customGatewayImage))
 		}
 		builder.WithProxyImage(imageParts[0], imageParts[1])
@@ -254,7 +254,7 @@ func configureKongAddon(cmd *cobra.Command, envBuilder *environments.Builder) *e
 		if len(imageParts) == 1 {
 			imageParts = append(imageParts, "latest")
 		}
-		if len(imageParts) != 2 { //nolint:gomnd
+		if len(imageParts) != 2 { //nolint:mnd
 			cobra.CheckErr(fmt.Errorf("malformed --kong-ingress-controller-image: %s", customControllerImage))
 		}
 		builder.WithControllerImage(imageParts[0], imageParts[1])
@@ -286,7 +286,7 @@ func configureKongAddon(cmd *cobra.Command, envBuilder *environments.Builder) *e
 // Environments - Delete Subcommand
 // -----------------------------------------------------------------------------
 
-func init() { //nolint:gochecknoinits
+func init() { //nolint:init
 	environmentsCmd.AddCommand(environmentsDeleteCmd)
 	environmentsDeleteCmd.PersistentFlags().String("name", DefaultEnvironmentName, "name of the environment to delete")
 }

--- a/internal/cmd/ktf/init.go
+++ b/internal/cmd/ktf/init.go
@@ -11,7 +11,7 @@ import (
 
 var cfgFile string
 
-func init() { //nolint:gochecknoinits
+func init() { //nolint:init
 	// config init
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ktf.yaml)")

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -478,7 +478,7 @@ func (a *Addon) DumpDiagnostics(ctx context.Context, cluster clusters.Cluster) (
 		opts := dbreconcilerutils.KongClientConfig{
 			Address: addr.String(),
 			HTTPClient: &http.Client{
-				Timeout: time.Second * 90, //nolint:gomnd
+				Timeout: time.Second * 90, //nolint:mnd
 			},
 			TLSConfig: dbreconcilerutils.TLSConfig{
 				SkipVerify: true,

--- a/pkg/clusters/addons/kong/enterprise_test.go
+++ b/pkg/clusters/addons/kong/enterprise_test.go
@@ -37,7 +37,7 @@ func TestGetLicenseJSON(t *testing.T) {
 	invalidLicense := &License{Data: LicenseData{Payload: LicensePayload{ExpirationDate: yesterdaysDateStr}}}
 	invalidLicenseJSON, err := json.Marshal(invalidLicense)
 	assert.NoError(t, err)
-	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(invalidLicenseJSON[:])))
+	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(invalidLicenseJSON)))
 	_, err = GetLicenseJSONFromEnv()
 	assert.Error(t, err)
 
@@ -45,7 +45,7 @@ func TestGetLicenseJSON(t *testing.T) {
 	invalidLicense = &License{Data: LicenseData{Payload: LicensePayload{ExpirationDate: "2021-10-20"}}}
 	invalidLicenseJSON, err = json.Marshal(invalidLicense)
 	assert.NoError(t, err)
-	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(invalidLicenseJSON[:])))
+	assert.NoError(t, os.Setenv(LicenseDataEnvVar, string(invalidLicenseJSON)))
 	_, err = GetLicenseJSONFromEnv()
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Sprintf("the provided %s is expired", LicenseDataEnvVar), err.Error())

--- a/pkg/clusters/addons/kuma/addon.go
+++ b/pkg/clusters/addons/kuma/addon.go
@@ -268,7 +268,7 @@ var (
 // enableMTLS attempts to apply a Mesh resource with a basic retry mechanism to deal with delays in the Kuma webhook
 // startup
 func (a *Addon) enableMTLS(ctx context.Context, cluster clusters.Cluster) (err error) {
-	ticker := time.NewTicker(5 * time.Second) //nolint:gomnd
+	ticker := time.NewTicker(5 * time.Second) //nolint:mnd
 	defer ticker.Stop()
 	timeoutTimer := time.NewTimer(time.Minute)
 

--- a/pkg/clusters/addons/metallb/metallb.go
+++ b/pkg/clusters/addons/metallb/metallb.go
@@ -221,7 +221,7 @@ func createIPAddressPool(ctx context.Context, cluster clusters.Cluster, dockerNe
 
 	res := dynamicClient.Resource(ipapResource).Namespace(DefaultNamespace)
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*3) //nolint:gomnd
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*3) //nolint:mnd
 	defer cancel()
 
 	var lastErr error

--- a/pkg/clusters/addons/registry/addon.go
+++ b/pkg/clusters/addons/registry/addon.go
@@ -184,7 +184,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	a.deploymentName = deployment.Name
 
 	// expose the deployment via Service
-	portMapping := map[int32]int32{registryListenPort: 443} //nolint:gomnd
+	portMapping := map[int32]int32{registryListenPort: 443} //nolint:mnd
 	service := generators.NewServiceForDeploymentWithMappedPorts(deployment, corev1.ServiceTypeClusterIP, portMapping)
 	if a.serviceTypeLoadBalancer {
 		service = generators.NewServiceForDeploymentWithMappedPorts(deployment, corev1.ServiceTypeLoadBalancer, portMapping)
@@ -358,7 +358,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 	// write the certificate to a tar archive, as needed for the docker client when
 	// copying files to containers.
 	containerID := dockerutils.GetKindContainerID(cluster.Name())
-	if err := dockerutils.WriteFileToContainer(ctx, containerID, registryCertPath, 0o644, crtPEM); err != nil { //nolint:gomnd
+	if err := dockerutils.WriteFileToContainer(ctx, containerID, registryCertPath, 0o644, crtPEM); err != nil { //nolint:mnd
 		return fmt.Errorf("failed to copy certificate to kind container: %w", err)
 	}
 
@@ -384,7 +384,7 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 
 	// create a new tar archive for the file contents, as required by the docker
 	// client api.
-	if err := dockerutils.WriteFileToContainer(ctx, containerID, containerdConfigPath, 0o644, containerdConfig.Bytes()); err != nil { //nolint:gomnd
+	if err := dockerutils.WriteFileToContainer(ctx, containerID, containerdConfigPath, 0o644, containerdConfig.Bytes()); err != nil { //nolint:mnd
 		return fmt.Errorf("could not write updated containerd configuration to kind container: %w", err)
 	}
 

--- a/pkg/clusters/cleanup.go
+++ b/pkg/clusters/cleanup.go
@@ -87,7 +87,7 @@ func (c *Cleaner) Cleanup(ctx context.Context) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 	// Limit the concurrency level to not overwhelm the API server.
-	g.SetLimit(8) //nolint:gomnd
+	g.SetLimit(8) //nolint:mnd
 
 	for _, namespace := range c.namespaces {
 		namespace := namespace
@@ -225,7 +225,7 @@ func resourceDeleterForObj(dyn *dynamic.DynamicClient, obj client.Object) delete
 
 // DumpDiagnostics dumps diagnostics from the underlying cluster.
 //
-// Deprecated. Users should use Cluster.DumpDiagnostics().
+// Deprecated: Users should use Cluster.DumpDiagnostics().
 func (c *Cleaner) DumpDiagnostics(ctx context.Context, meta string) (string, error) {
 	return c.cluster.DumpDiagnostics(ctx, meta)
 }

--- a/pkg/clusters/diagnostics.go
+++ b/pkg/clusters/diagnostics.go
@@ -28,12 +28,12 @@ func DumpAllDescribeAll(ctx context.Context, c Cluster, outDir string) error {
 	// kubectl api-resources --verbs=list --namespaced -o name  | xargs -n 1 kubectl get --show-kind --ignore-not-found -A -oyaml
 	// kubectl api-resources --verbs=list --namespaced -o name  | xargs -n 1 kubectl get --show-kind --ignore-not-found -A -oyaml
 	// aka "kubectl get all" and "kubectl describe all", but also gets CRs and cluster-scoped resouces
-	getAllOut, err := os.OpenFile(filepath.Join(outDir, "kubectl_get_all.yaml"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gomnd
+	getAllOut, err := os.OpenFile(filepath.Join(outDir, "kubectl_get_all.yaml"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
 	if err != nil {
 		return err
 	}
 	defer getAllOut.Close()
-	describeAllOut, err := os.OpenFile(filepath.Join(outDir, "kubectl_describe_all.txt"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gomnd
+	describeAllOut, err := os.OpenFile(filepath.Join(outDir, "kubectl_describe_all.txt"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func DumpDiagnostics(ctx context.Context, c Cluster, meta string, outDir string)
 		}
 		if len(diagnostics) > 0 {
 			addonOut := filepath.Join(outDir, "addons", string(addon.Name()))
-			err = os.MkdirAll(addonOut, 0o750) //nolint:gomnd
+			err = os.MkdirAll(addonOut, 0o750) //nolint:mnd
 			if err != nil {
 				failedAddons[string(addon.Name())] = err
 				continue
@@ -142,7 +142,7 @@ func DumpDiagnostics(ctx context.Context, c Cluster, meta string, outDir string)
 	// write errors if we failed to dump results of `kubectl get all` or `kubectl describe all`.
 	// in cases where kubernetes cluster may not be correctly created.
 	if err != nil {
-		kubectlErrorOut, openErr := os.OpenFile(filepath.Join(outDir, "kubectl_dump_error.txt"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gomnd
+		kubectlErrorOut, openErr := os.OpenFile(filepath.Join(outDir, "kubectl_dump_error.txt"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
 		if openErr != nil {
 			return openErr
 		}

--- a/pkg/clusters/types/gke/cluster.go
+++ b/pkg/clusters/types/gke/cluster.go
@@ -242,7 +242,7 @@ func (c *Cluster) DumpDiagnostics(ctx context.Context, meta string) (string, err
 		return outDir, err
 	}
 	logsDir := filepath.Join(outDir, "pod_logs")
-	err = os.Mkdir(logsDir, 0o750) //nolint:gomnd
+	err = os.Mkdir(logsDir, 0o750) //nolint:mnd
 	if err != nil {
 		return outDir, err
 	}

--- a/pkg/clusters/types/kind/utils.go
+++ b/pkg/clusters/types/kind/utils.go
@@ -134,7 +134,7 @@ func (b *Builder) disableDefaultCNI() error {
 		return fmt.Errorf("failed marshalling kind config: %w", err)
 	}
 
-	err = os.WriteFile(*b.configPath, configYAML, 0o600) //nolint:gomnd
+	err = os.WriteFile(*b.configPath, configYAML, 0o600) //nolint:mnd
 	if err != nil {
 		return fmt.Errorf("failed writing kind config %s: %w", *b.configPath, err)
 	}
@@ -166,7 +166,7 @@ func (b *Builder) useIPv6Only() error {
 		return fmt.Errorf("failed marshalling kind config: %w", err)
 	}
 
-	err = os.WriteFile(*b.configPath, configYAML, 0o600) //nolint:gomnd
+	err = os.WriteFile(*b.configPath, configYAML, 0o600) //nolint:mnd
 	if err != nil {
 		return fmt.Errorf("failed writing kind config %s: %w", *b.configPath, err)
 	}

--- a/pkg/environments/builder.go
+++ b/pkg/environments/builder.go
@@ -103,13 +103,14 @@ func (b *Builder) Build(ctx context.Context) (env Environment, err error) {
 		return nil, fmt.Errorf("Environment cannot specify both existingCluster and clusterBuilder")
 	}
 
-	// determine if an existing cluster has been configured for deployment
-	if b.existingCluster != nil {
+	// Determine if an existing cluster has been configured for deployment.
+	switch {
+	case b.existingCluster != nil:
 		if b.kubernetesVersion != nil {
 			return nil, fmt.Errorf("can't provide kubernetes version when using an existing cluster")
 		}
 		cluster = b.existingCluster
-	} else if b.clusterBuilder != nil {
+	case b.clusterBuilder != nil:
 		if b.kubernetesVersion != nil {
 			return nil, fmt.Errorf("can't provide kubernetes version when providing a cluster builder")
 		}
@@ -117,7 +118,7 @@ func (b *Builder) Build(ctx context.Context) (env Environment, err error) {
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	default:
 		builder := kind.NewBuilder().WithName(b.Name)
 		if b.kubernetesVersion != nil {
 			builder.WithClusterVersion(*b.kubernetesVersion)

--- a/pkg/utils/kubernetes/kubectl/kustomize.go
+++ b/pkg/utils/kubernetes/kubectl/kustomize.go
@@ -26,7 +26,7 @@ func GetKustomizedManifest(kustomization types.Kustomization, manifests ...io.Re
 		if err != nil {
 			return nil, err
 		}
-		err = os.WriteFile(filepath.Join(workDir, fmt.Sprintf("resource_%d.yaml", i)), orig, 0o600) //nolint:gomnd
+		err = os.WriteFile(filepath.Join(workDir, fmt.Sprintf("resource_%d.yaml", i)), orig, 0o600) //nolint:mnd
 		if err != nil {
 			return nil, err
 		}
@@ -36,7 +36,7 @@ func GetKustomizedManifest(kustomization types.Kustomization, manifests ...io.Re
 	if err != nil {
 		return nil, err
 	}
-	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), marshalled, 0o600) //nolint:gomnd
+	err = os.WriteFile(filepath.Join(workDir, "kustomization.yaml"), marshalled, 0o600) //nolint:mnd
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/networking/http.go
+++ b/pkg/utils/networking/http.go
@@ -15,7 +15,7 @@ import (
 func WaitForHTTP(ctx context.Context, getURL string, statusCode int) chan error {
 	errs := make(chan error)
 	go func() {
-		httpc := http.Client{Timeout: time.Second * 10} //nolint:gomnd
+		httpc := http.Client{Timeout: time.Second * 10} //nolint:mnd
 		for {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
Since `gocritic` has been introduced in

- https://github.com/Kong/gateway-operator/pull/101
- https://github.com/Kong/kubernetes-ingress-controller/pull/5899

let's keep our coding standards consistent across managed projects and use `gocritic` in KTF too.

Moreover, it does housekeeping like fixing all warnings of deprecated linters, adjusting config, etc.