### PR TITLE
chore(ci): set timeouts in remaining CI files and adjust linter name in //nolint

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   analyze:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -14,6 +14,7 @@ jobs:
   # --------------------------------------------------------------------------
 
   unit-tests:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
 
@@ -31,6 +32,7 @@ jobs:
       run: make test.unit
 
   setup-integration-tests:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     outputs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
@@ -84,6 +86,7 @@ jobs:
         TEST_RUN: ${{ matrix.test }}
 
   e2e-tests:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     environment: gcloud
     runs-on: ubuntu-latest
     steps:
@@ -117,6 +120,7 @@ jobs:
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
   release-tagging:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs:
     - unit-tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
 
   artifacts:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -70,6 +71,7 @@ jobs:
   # --------------------------------------------------------------------------
 
   release:
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     needs:
     - artifacts

--- a/internal/cmd/ktf/environments.go
+++ b/internal/cmd/ktf/environments.go
@@ -25,7 +25,7 @@ import (
 // Environments - Base Command
 // -----------------------------------------------------------------------------
 
-func init() { //nolint:init
+func init() { //nolint:gochecknoinits
 	rootCmd.AddCommand(environmentsCmd)
 }
 
@@ -39,7 +39,7 @@ var environmentsCmd = &cobra.Command{
 // Environments - Create Subcommand
 // -----------------------------------------------------------------------------
 
-func init() { //nolint:init
+func init() { //nolint:gochecknoinits
 	environmentsCmd.AddCommand(environmentsCreateCmd)
 
 	// environment naming
@@ -286,7 +286,7 @@ func configureKongAddon(cmd *cobra.Command, envBuilder *environments.Builder) *e
 // Environments - Delete Subcommand
 // -----------------------------------------------------------------------------
 
-func init() { //nolint:init
+func init() { //nolint:gochecknoinits
 	environmentsCmd.AddCommand(environmentsDeleteCmd)
 	environmentsDeleteCmd.PersistentFlags().String("name", DefaultEnvironmentName, "name of the environment to delete")
 }

--- a/internal/cmd/ktf/init.go
+++ b/internal/cmd/ktf/init.go
@@ -11,7 +11,7 @@ import (
 
 var cfgFile string
 
-func init() { //nolint:init
+func init() { //nolint:gochecknoinits
 	// config init
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ktf.yaml)")


### PR DESCRIPTION
Supersedes #950, #952, #953, #954

Naming fix [inits -> gochecknoinits](https://golangci-lint.run/product/changelog/#v1581)