### PR TITLE
fix: adapt to kong chart v2.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.47.1
+
+- Adapt Kong addon to the `kong/kong` Helm chart v2.39.0 that requires
+  `enterprise.rbac.session_conf_secret` to be explicitly defined.
+  [#1105](https://github.com/Kong/kubernetes-testing-framework/pull/1105)
 
 ## v0.47.0
 

--- a/pkg/clusters/addons/kong/addon.go
+++ b/pkg/clusters/addons/kong/addon.go
@@ -360,6 +360,9 @@ func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
 			}
 		}
 
+		// Set the session configuration secret name for the admin GUI.
+		a.deployArgs = append(a.deployArgs, "--set", fmt.Sprintf("enterprise.rbac.session_conf_secret=%s", DefaultAdminGUISessionConfSecretName))
+
 		// Deploy the admin session configuration needed for enterprise enabled mode.
 		if err := deployKongEnterpriseAdminGUISessionConf(ctx, cluster, a.namespace); err != nil {
 			return err


### PR DESCRIPTION
`kong/kong` chart from v2.39 no longer sets the default value of `enterprise.rbac.session_conf_secret` (https://github.com/Kong/charts/pull/1033). This PR fixes an issue discovered in KIC's integration tests (https://github.com/Kong/kubernetes-ingress-controller/pull/6198) that makes Kong complain about missing `admin_gui_session_conf` caused by KTF relying on the default in charts.

Tested in https://github.com/Kong/kubernetes-ingress-controller/pull/6198 by manual KTF bump to this branch.