### PR TITLE
chore: extend e2e tests' timeout

### DIFF
--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -86,7 +86,7 @@ jobs:
         TEST_RUN: ${{ matrix.test }}
 
   e2e-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 30 # Setting up a GKE cluster and getting a LB ready can take more than the default 10m.
     environment: gcloud
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Drop the e2e tests job's timeout set from organization's vars as it's not enough: https://github.com/Kong/kubernetes-testing-framework/actions/runs/9550375317/job/26324041269