### PR TITLE
chore(ci): hardcode timeouts

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   analyze:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   golangci-lint:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - name: checkout repository

--- a/.github/workflows/release-testing.yaml
+++ b/.github/workflows/release-testing.yaml
@@ -14,7 +14,7 @@ jobs:
   # --------------------------------------------------------------------------
 
   unit-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
 
@@ -32,7 +32,7 @@ jobs:
       run: make test.unit
 
   setup-integration-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
@@ -120,7 +120,7 @@ jobs:
         KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
   release-tagging:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs:
     - unit-tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   artifacts:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
   # --------------------------------------------------------------------------
 
   release:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs:
     - artifacts

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   installer-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
 
@@ -33,7 +33,7 @@ jobs:
       run: ~/.local/bin/ktf
 
   unit-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
 
@@ -69,7 +69,7 @@ jobs:
         attempt_delay: 30000
 
   setup-integration-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
@@ -152,7 +152,7 @@ jobs:
         attempt_delay: 30000
 
   integration-tests-passed:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     needs: integration-tests
     if: always()
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
           exit 1
 
   setup-e2e-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       test_names: ${{ steps.set_test_names.outputs.test_names }}
@@ -229,7 +229,7 @@ jobs:
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
   e2e-tests-passed:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 10
     needs: e2e-tests
     if: always() && !contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Using variables is not supported in PRs from forks, ref: https://github.com/orgs/community/discussions/44322

This PR hardcodes the timeouts (as these are the only variables that are used) to enable PRs from forks to be accepted.