### PR TITLE
fix: use controller-runtime client in cleaner

### DIFF
--- a/pkg/clusters/cleanup_test.go
+++ b/pkg/clusters/cleanup_test.go
@@ -4,128 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func TestFixupObjKinds(t *testing.T) {
-	testcases := []struct {
-		name     string
-		obj      client.Object
-		expected schema.GroupVersionKind
-	}{
-		{
-			name: "gatewayclass",
-			obj: &gatewayv1.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-gatewayclass",
-				},
-			},
-			expected: schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "GatewayClass",
-			},
-		},
-		{
-			name: "gateway",
-			obj: &gatewayv1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-gateway",
-				},
-			},
-			expected: schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "Gateway",
-			},
-		},
-		{
-			name: "httproute",
-			obj: &gatewayv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-httproute",
-				},
-			},
-			expected: schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "HTTPRoute",
-			},
-		},
-		{
-			name: "tcproute",
-			obj: &gatewayv1alpha2.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-tcproute",
-				},
-			},
-			expected: schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1alpha2",
-				Kind:    "TCPRoute",
-			},
-		},
-		{
-			name: "udproute",
-			obj: &gatewayv1alpha2.UDPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-udproute",
-				},
-			},
-			expected: schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1alpha2",
-				Kind:    "UDPRoute",
-			},
-		},
-		{
-			name: "tlsroute",
-			obj: &gatewayv1alpha2.TLSRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-tlsroute",
-				},
-			},
-			expected: schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1alpha2",
-				Kind:    "TLSRoute",
-			},
-		},
-		{
-			name: "referencegrant",
-			obj: &gatewayv1beta1.ReferenceGrant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-referencegrant",
-				},
-			},
-			expected: schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1beta1",
-				Kind:    "ReferenceGrant",
-			},
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			obj := fixupObjKinds(tc.obj)
-			assert.Equal(t, tc.expected.Group, obj.GetObjectKind().GroupVersionKind().Group)
-			assert.Equal(t, tc.expected.Kind, obj.GetObjectKind().GroupVersionKind().Kind)
-			assert.Equal(t, tc.expected.Version, obj.GetObjectKind().GroupVersionKind().Version)
-		})
-	}
-}
-
 func TestCleanerCanBeUsedConcurrently(*testing.T) {
-	cleaner := NewCleaner(nil)
-	for i := 0; i < 100; i++ {
+	cleaner := NewCleaner(nil, runtime.NewScheme())
+	for i := range 100 {
 		go func() {
 			cleaner.Add(&corev1.Pod{})
 		}()

--- a/test/integration/cleaner_test.go
+++ b/test/integration/cleaner_test.go
@@ -11,6 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -32,7 +34,10 @@ func TestCleaner(t *testing.T) {
 	require.NoError(t, err)
 
 	cluster := env.Cluster()
-	cleaner := clusters.NewCleaner(cluster)
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+	cleaner := clusters.NewCleaner(cluster, scheme)
 	t.Cleanup(func() { cleaner.Cleanup(context.Background()) })
 
 	t.Log("waiting for the test environment to be ready")


### PR DESCRIPTION
Already used by https://github.com/Kong/kong-operator/pull/1990.