### PR TITLE
chore(ci): fix release permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - artifacts
+    permissions:
+      contents: write
     steps:
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
Fix: https://github.com/Kong/kubernetes-testing-framework/actions/runs/16810322113/job/47613821381

```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release","status":"403"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```